### PR TITLE
ci: Rename formatting action to resolve ambiguity.

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   format:
-    name: cargo test
+    name: cargo fmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
My copypasta from the ci yaml left the formatting job with the name 'cargo test'. This causes confusion when looking at the  actions in the github UI.