### PR TITLE
Give clippy some teeth.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
         with:
           components: clippy
       - run: sudo apt-get install -y pkg-config libudev-dev
-      - run: cargo clippy
+      - run: cargo clippy -- --deny warnings
   test:
     name: cargo test
     runs-on: ubuntu-latest


### PR DESCRIPTION
This causes the action to fail when a clippy lint classified as a warning is found. Lint groups complexity, perf, style and suspicious are all reported as warnings according to:
https://rust-lang.github.io/rust-clippy/