### PR TITLE
wip: replace `pem` with `pem-rfc7468` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
  "dice-mfg-msgs",
  "env_logger 0.9.3",
  "log",
- "pem",
+ "pem-rfc7468 0.7.0",
  "serialport",
  "string-error",
  "tempfile",
@@ -723,6 +723,15 @@ version = "0.7.0-pre"
 source = "git+https://github.com/RustCrypto/formats#9c3ad4366d7f6132d770fe1ead839fbca295cff9"
 dependencies = [
  "base64ct 1.5.3 (git+https://github.com/RustCrypto/formats)",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/dice-mfg/Cargo.toml
+++ b/dice-mfg/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4", features = ["derive", "env"] }
 dice-mfg-msgs = { path = "../dice-mfg-msgs" }
 env_logger = "0.9"
 log = "0.4"
-pem = "1"
+pem-rfc7468 = { version = "0.7.0", features = ["alloc", "std"] }
 serialport = "4"
 string-error = "0.1"
 tempfile = "3.3"


### PR DESCRIPTION
this will resolve https://github.com/oxidecomputer/dice-util/issues/50 but I've left it as a draft because the CSRs it produces are padded with a stream of 'A's like so:

```
-----BEGIN CERTIFICATE REQUEST-----
MIHZMIGMAgEAMFkxCzAJBgNVBAYTAlVTMR8wHQYDVQQKDBZPeGlkZSBDb21wdXRl
ciBDb21wYW55MSkwJwYDVQQDDCAwWFYyOlBQUC1QUFBQUFBQOlJSUjpMTExXV1lZ
U1NTNjAqMAUGAytlcAMhAFhzsGg1Hh1KHIh/RZLENut5X4VLU6wFLqMaqW7wiED5
oAAwBQYDK2VwA0EAhfRVmnN50lqtNntw/8tQ2wOJdBW+pua0EjPJHLb/XYmPyjo1
ghQg5+Y9ZQqKlmOeufpkJ3dGF6VTSdvXWg5CAQAAAAAAAAAAAAAAAAAAAAAAAAAA
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-----END CERTIFICATE REQUEST-----
```

 I don't have time to figure out whether I've done something wrong, this is expected behavior (check rfc 7468), or it's something else / bug. It handles certs fine and is a drop-in replacement for the existing implementation (decodes certs created by opensl fine).