### PR TITLE
dice-mfg-msgs: Add 'std' feature, use thiserror when its enabled.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -243,7 +243,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -300,6 +300,7 @@ dependencies = [
  "hubpack",
  "serde",
  "serde-big-array",
+ "thiserror",
  "zerocopy",
 ]
 
@@ -533,7 +534,7 @@ checksum = "0f928320aff16ee8818ef7309180f8b5897057fd79d9dcb8de3ed1ba6dcc125a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -759,7 +760,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -776,18 +777,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -937,7 +938,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1039,6 +1040,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,22 +1074,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1131,7 +1143,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -1153,7 +1165,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1315,7 +1327,7 @@ checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]

--- a/dice-mfg-msgs/Cargo.toml
+++ b/dice-mfg-msgs/Cargo.toml
@@ -8,4 +8,8 @@ corncobs = "0.1.3"
 hubpack = "0.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-big-array = "0.4"
+thiserror = { version = "1.0.40", optional = true }
 zerocopy = "0.6"
+
+[features]
+std = ["thiserror"]

--- a/dice-mfg/Cargo.toml
+++ b/dice-mfg/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 [dependencies]
 anyhow = "1.0.71"
 clap = { version = "4", features = ["derive", "env"] }
-dice-mfg-msgs = { path = "../dice-mfg-msgs" }
+dice-mfg-msgs = { path = "../dice-mfg-msgs", features = ["std"] }
 env_logger = "0.9"
 log = "0.4"
 pem = "1"

--- a/dice-mfg/src/lib.rs
+++ b/dice-mfg/src/lib.rs
@@ -158,7 +158,7 @@ impl MfgDriver {
             MfgMessage::Nak => return Err(Error::NoPlatformId.into()),
             _ => {
                 warn!("requested CSR, got unexpected response: \"{:?}\"", recv);
-                return Err(Error::WrongMsg(recv.as_str().to_string()).into());
+                return Err(Error::WrongMsg(recv.to_string()).into());
             }
         };
 
@@ -208,7 +208,7 @@ impl MfgDriver {
             MfgMessage::Ack => Ok(()),
             _ => {
                 warn!("expected Ack, got unexpected message: \"{:?}\"", resp);
-                Err(Error::WrongMsg(resp.as_str().to_string()).into())
+                Err(Error::WrongMsg(resp.to_string()).into())
             }
         }
     }


### PR DESCRIPTION
Implementing 'Error' requires we implement 'Display' so we use this to replace some of the ill advised stuff I was doing with 'to_str()'.