### PR TITLE
dice-mfg: Get password from env, allow caller to set auth-id used.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,10 +286,12 @@ dependencies = [
  "env_logger 0.9.3",
  "log",
  "pem",
+ "rpassword",
  "serialport",
  "string-error",
  "tempfile",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -874,6 +876,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "winapi",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1355,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/dice-mfg/Cargo.toml
+++ b/dice-mfg/Cargo.toml
@@ -12,7 +12,9 @@ dice-mfg-msgs = { path = "../dice-mfg-msgs", features = ["std"] }
 env_logger = "0.9"
 log = "0.4"
 pem = "1"
+rpassword = "7.2.0"
 serialport = "4"
 string-error = "0.1"
 tempfile = "3.3"
 zerocopy = "0.6"
+zeroize = { version = "1.6.0", features = ["std", "alloc"] }

--- a/dice-mfg/src/lib.rs
+++ b/dice-mfg/src/lib.rs
@@ -17,6 +17,10 @@ use std::{
     process::Command,
 };
 
+// string for environment variable used to pass in the authentication
+// password for the HSM
+pub const ENV_PASSWD: &str = "DICE_MFG_PKCS11_AUTH";
+
 #[derive(Debug, PartialEq)]
 pub enum Error {
     BadTag,
@@ -376,7 +380,9 @@ impl CertSigner {
             cmd.arg("-engine")
                 .arg(section)
                 .arg("-keyform")
-                .arg("engine");
+                .arg("engine")
+                .arg("-passin")
+                .arg(format!("env:{ENV_PASSWD}"));
         }
 
         info!("cmd: {:?}", cmd);


### PR DESCRIPTION
The object-id for the auth credential (auth-id) and the associated password get combined as a hack to plumb this data through the PKCS#11 auth APIs. It would have been more simple for us to just have whatever sets the password in the environment to include the object-id of the auth token too. Somehow passing the auth-id and then combining them programatically felt more natural.

This resolves #44