### PR TITLE
Fix misleading comments on env var strings for passwords.

### DIFF
--- a/dice-mfg/src/lib.rs
+++ b/dice-mfg/src/lib.rs
@@ -20,12 +20,14 @@ use std::{
 use yubihsm::{object::Id, Client, Connector, Credentials, HttpConfig};
 use zeroize::Zeroizing;
 
-// string for environment variable used to pass in the authentication
-// password for the HSM
+// Name of environment variable used to pass in the YubiHSM password into
+// the application.
 pub const ENV_PASSWD: &str = "DICE_MFG_YUBIHSM_AUTH";
-// string for environment variable used to pass in the authentication
-// password for the HSM
-pub const ENV_PASSWD_PKCS11: &str = "DICE_MFG_PKCS11_AUTH";
+
+// Name of environment variable used to pass the YubiHSM password through
+// openssl & PKCS#11 module to the YubiHSM. This variable is set should
+// *not* be set by the caller.
+const ENV_PASSWD_PKCS11: &str = "DICE_MFG_PKCS11_AUTH";
 
 // default object id for auth credential from oks
 pub const DEFAULT_AUTH_ID: Id = 2;

--- a/dice-mfg/src/main.rs
+++ b/dice-mfg/src/main.rs
@@ -22,6 +22,9 @@ use dice_mfg::{CertSignerBuilder, MfgDriver, DEFAULT_AUTH_ID, ENV_PASSWD};
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 /// Send commands to the RoT for DeviceId certification.
+/// We explicitly do not allow providing the YubiHSM password as an option.
+/// To prevent interactive password entry set the `DICE_MFG_YUBIHSM_AUTH`
+/// environment variable.
 struct Args {
     /// serial port device path
     #[clap(long, default_value = "/dev/ttyACM0", env = "DICE_MFG_SERIAL_DEV")]


### PR DESCRIPTION
Additionally we no longer export the `ENV_PASSWD_PKCS11` constant to make it clear that it's only used internal to the module.