### PR TITLE
Add sha3-256 hash to Ack message as integrity check.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "rpassword",
  "serde_json",
  "serialport",
+ "sha3",
  "string-error",
  "tempfile",
  "yubihsm",
@@ -857,6 +858,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1380,6 +1390,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]

--- a/dice-mfg-msgs/src/lib.rs
+++ b/dice-mfg-msgs/src/lib.rs
@@ -9,6 +9,9 @@ use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
 
+pub type MessageHash = [u8; 32];
+pub const NULL_HASH: MessageHash = [0u8; 32];
+
 const BLOB_SIZE: usize = 768;
 
 #[derive(Clone, Debug, Deserialize, Serialize, SerializedSize)]
@@ -302,7 +305,7 @@ pub enum Error {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Deserialize, Serialize, SerializedSize)]
 pub enum MfgMessage {
-    Ack,
+    Ack(MessageHash),
     Break,
     Csr(SizedBlob),
     CsrPlz,
@@ -321,7 +324,7 @@ pub enum MfgMessage {
 impl fmt::Display for MfgMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            MfgMessage::Ack => write!(f, "MfgMessage::Ack"),
+            MfgMessage::Ack(hash) => write!(f, "MfgMessage::Ack: {:?}", hash),
             MfgMessage::Break => write!(f, "MfgMessage::Break"),
             MfgMessage::Csr(_) => write!(f, "MfgMessage::Csr"),
             MfgMessage::CsrPlz => write!(f, "MfgMessage::CsrPlz"),

--- a/dice-mfg/Cargo.toml
+++ b/dice-mfg/Cargo.toml
@@ -16,6 +16,7 @@ pem = "1"
 rpassword = "7.2.0"
 serde_json = { version = "1.0.96", features = ["std", "alloc"] }
 serialport = { git = "https://github.com/jgallagher/serialport-rs", branch = "illumos-support" }
+sha3 = { version = "0.10.8" }
 string-error = "0.1"
 tempfile = "3.3"
 yubihsm = { git = "https://github.com/oxidecomputer/yubihsm.rs" }


### PR DESCRIPTION
This allows us to check that the RoT received any message that responds with Ack. This includes all of the messages that we care about including: the platforms unique id, it's identity cert and the cert for the issuing intermediate CA. All other messages that require an Ack (Break & Ping) will reply with 32 bytes of 0's.