### PR TITLE
Check release config before manufacturing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+*.swp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "dice-mfg-msgs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "corncobs",
  "hubpack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "dice-mfg"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dice-mfg-msgs/Cargo.toml
+++ b/dice-mfg-msgs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dice-mfg-msgs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]

--- a/dice-mfg-msgs/src/lib.rs
+++ b/dice-mfg-msgs/src/lib.rs
@@ -278,6 +278,13 @@ impl PlatformId {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize, SerializedSize)]
+pub enum KeySlotStatus {
+    Invalid,
+    Enabled,
+    Revoked,
+}
+
 #[cfg_attr(any(test, feature = "std"), derive(thiserror::Error))]
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -321,6 +328,10 @@ pub enum MfgMessage {
         cmpa_locked: bool,
         syscon_locked: bool,
     },
+    GetKeySlotStatus,
+    KeySlotStatus {
+        slots: [KeySlotStatus; 4],
+    },
 }
 
 impl fmt::Display for MfgMessage {
@@ -342,6 +353,12 @@ impl fmt::Display for MfgMessage {
             MfgMessage::YouLockedBro => f.write_str("MfgMessage::YouLockedBro"),
             MfgMessage::LockStatus { .. } => {
                 f.write_str("MfgMessage::LockStatus")
+            }
+            MfgMessage::GetKeySlotStatus => {
+                f.write_str("MfgMessage::GetKeySlotStatus")
+            }
+            MfgMessage::KeySlotStatus { .. } => {
+                f.write_str("MfgMessage::KeySlotStatus")
             }
         }
     }

--- a/dice-mfg/Cargo.toml
+++ b/dice-mfg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dice-mfg"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A command line tool for creating and programming device identities for Oxide RoTs."
 license = "MPL-2.0"

--- a/dice-mfg/src/main.rs
+++ b/dice-mfg/src/main.rs
@@ -182,6 +182,11 @@ enum Command {
         /// Path to input CSR file.
         csr_in: PathBuf,
     },
+    /// Asks the firmware for its opinion on which secure boot key slots are
+    /// enabled on the device it's running on.
+    ///
+    /// You can only trust this as far as you trust the firmware, of course.
+    GetKeySlotStatus,
 }
 
 fn open_serial(serial_dev: &str, baud: u32) -> Result<Box<dyn SerialPort>> {
@@ -342,6 +347,18 @@ fn main() -> Result<()> {
             if !dice_mfg::check_csr(&csr_in, &platform_id)? {
                 bail!("CSR does not meet policy requirements");
             }
+            Ok(())
+        }
+        Command::GetKeySlotStatus => {
+            for (slot, status) in driver
+                .unwrap()
+                .get_key_slot_status()?
+                .into_iter()
+                .enumerate()
+            {
+                println!("Slot {}: {:?}", slot, status);
+            }
+
             Ok(())
         }
     }


### PR DESCRIPTION
- dice-mfg-msgs: messages to query key slot status
- dice-mfg: subcommand to query key slot status
- dice-mfg manufacture: require device is in release configuration before starting
- fix
- dice-mfg: bump version
- .gitignore: ignore Rust target/ directory
