### PR TITLE
Cert check dep cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,11 +105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
-name = "base64ct"
-version = "1.5.3"
-source = "git+https://github.com/RustCrypto/formats#9c3ad4366d7f6132d770fe1ead839fbca295cff9"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,11 +249,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
-name = "const-oid"
-version = "0.10.0-pre"
-source = "git+https://github.com/RustCrypto/formats#9c3ad4366d7f6132d770fe1ead839fbca295cff9"
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,20 +324,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid 0.9.4",
- "pem-rfc7468 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/formats#9c3ad4366d7f6132d770fe1ead839fbca295cff9"
-dependencies = [
- "const-oid 0.10.0-pre",
- "der_derive 0.7.0-pre",
- "flagset",
- "pem-rfc7468 0.7.0-pre",
+ "const-oid",
  "zeroize",
 ]
 
@@ -357,22 +334,11 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
 dependencies = [
- "const-oid 0.9.4",
- "der_derive 0.7.1",
+ "const-oid",
+ "der_derive",
  "flagset",
- "pem-rfc7468 0.7.0",
+ "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/formats#9c3ad4366d7f6132d770fe1ead839fbca295cff9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
 ]
 
 [[package]]
@@ -406,17 +372,16 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "const-oid 0.10.0-pre",
- "ecdsa 0.16.7",
+ "const-oid",
  "env_logger",
  "hex",
  "log",
- "p384 0.12.0",
- "pem-rfc7468 0.7.0-pre",
+ "p384 0.13.0",
+ "pem-rfc7468",
  "ring-compat",
  "sha2",
  "thiserror",
- "x509-cert 0.2.0-pre",
+ "x509-cert",
 ]
 
 [[package]]
@@ -437,7 +402,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "const-oid 0.9.4",
+ "const-oid",
  "corncobs",
  "dice-mfg-msgs",
  "env_logger",
@@ -449,7 +414,7 @@ dependencies = [
  "sha3",
  "string-error",
  "tempfile",
- "x509-cert 0.2.4",
+ "x509-cert",
  "yubihsm",
  "zerocopy",
  "zeroize",
@@ -474,7 +439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid 0.9.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -487,7 +452,6 @@ checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
 dependencies = [
  "der 0.6.1",
  "elliptic-curve 0.12.3",
- "rfc6979 0.3.1",
  "signature 2.0.0",
 ]
 
@@ -500,8 +464,9 @@ dependencies = [
  "der 0.7.6",
  "digest",
  "elliptic-curve 0.13.4",
- "rfc6979 0.4.0",
+ "rfc6979",
  "signature 2.0.0",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -535,9 +500,6 @@ dependencies = [
  "ff 0.12.1",
  "generic-array",
  "group 0.12.1",
- "hkdf",
- "pem-rfc7468 0.6.0",
- "pkcs8",
  "rand_core",
  "sec1 0.3.0",
  "subtle",
@@ -556,6 +518,9 @@ dependencies = [
  "ff 0.13.0",
  "generic-array",
  "group 0.13.0",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
  "rand_core",
  "sec1 0.7.1",
  "subtle",
@@ -982,7 +947,6 @@ dependencies = [
  "ecdsa 0.15.1",
  "elliptic-curve 0.12.3",
  "primeorder 0.12.1",
- "sha2",
 ]
 
 [[package]]
@@ -1018,28 +982,11 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
-dependencies = [
- "base64ct 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/formats#9c3ad4366d7f6132d770fe1ead839fbca295cff9"
-dependencies = [
- "base64ct 1.5.3 (git+https://github.com/RustCrypto/formats)",
-]
-
-[[package]]
-name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
- "base64ct 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64ct",
 ]
 
 [[package]]
@@ -1050,6 +997,16 @@ checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der 0.6.1",
  "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.6",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -1155,17 +1112,6 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
-]
-
-[[package]]
-name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
@@ -1203,7 +1149,7 @@ dependencies = [
  "opaque-debug",
  "p256 0.12.0",
  "p384 0.12.0",
- "pkcs8",
+ "pkcs8 0.9.0",
  "ring",
  "signature 2.0.0",
 ]
@@ -1313,7 +1259,7 @@ dependencies = [
  "base16ct 0.1.1",
  "der 0.6.1",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.9.0",
  "subtle",
  "zeroize",
 ]
@@ -1327,6 +1273,7 @@ dependencies = [
  "base16ct 0.2.0",
  "der 0.7.6",
  "generic-array",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -1454,17 +1401,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
- "base64ct 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64ct",
  "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/formats#9c3ad4366d7f6132d770fe1ead839fbca295cff9"
-dependencies = [
- "base64ct 1.5.3 (git+https://github.com/RustCrypto/formats)",
- "der 0.7.0-pre",
 ]
 
 [[package]]
@@ -1473,7 +1411,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
- "base64ct 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64ct",
  "der 0.7.6",
 ]
 
@@ -1869,22 +1807,11 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "x509-cert"
-version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/formats#9c3ad4366d7f6132d770fe1ead839fbca295cff9"
-dependencies = [
- "const-oid 0.10.0-pre",
- "der 0.7.0-pre",
- "flagset",
- "spki 0.7.0-pre",
-]
-
-[[package]]
-name = "x509-cert"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25eefca1d99701da3a57feb07e5079fc62abba059fc139e98c13bbb250f3ef29"
 dependencies = [
- "const-oid 0.9.4",
+ "const-oid",
  "der 0.7.6",
  "spki 0.7.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,14 @@ chrono = { version = "0.4.26", default-features=false }
 clap = { version = "4", default-features = false }
 corncobs = "0.1"
 derive_more = "0.99"
-env_logger = "0.10"
-hex = "0.4"
+ecdsa = { version = "0.16", default-features = false }
+env_logger = { version = "0.10", default-features = false }
+hex = { version = "0.4", default-features = false }
 hubpack = "0.1"
 log = { version = "0.4", features = ["std"] }
+p384 = { version = "0.12.0", default-features = false }
 pem = { version = "1", default-features = false }
+ring-compat = { version = "0.6", default-features = false }
 ron = "0.8"
 rpassword = "7.2.0"
 salty = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ env_logger = { version = "0.10", default-features = false }
 hex = { version = "0.4", default-features = false }
 hubpack = "0.1"
 log = { version = "0.4", features = ["std"] }
-p384 = { version = "0.12.0", default-features = false }
+p384 = { version = "0.13", default-features = false }
 pem = { version = "1", default-features = false }
+pem-rfc7468 = { version = "0.7.0", default-features = false }
 ring-compat = { version = "0.6", default-features = false }
 ron = "0.8"
 rpassword = "7.2.0"

--- a/dice-cert-check/Cargo.toml
+++ b/dice-cert-check/Cargo.toml
@@ -3,23 +3,16 @@ name = "dice-cert-check"
 version = "0.1.0"
 edition = "2021"
 
-# NOTE: We're currently using crates from the main development branch of the
-# rust crypto formats git repo. We do this because:
-# - const-oid doesn't have the OIDs from RFC 8410 in a release yet
-# - the latest x509-cert release has a bug that prevents us from consuming
-#   PEM encoded certs. This has been fixed on the development branch but
-#   hasn't made it into a release yet.
 [dependencies]
 anyhow = { workspace = true, default-features = true }
 clap = { workspace = true, default-features = true, features = ["derive"] }
-const-oid = { git = "https://github.com/RustCrypto/formats" }
+const-oid = { version = "0.9.4", features = ["db"] }
 env_logger = { workspace = true, default-features = true }
-ecdsa = { workspace = true, default-features = true }
 hex = { workspace = true, default-features = true }
 log = { workspace = true, default-features = true, features = ["std"] }
 p384 = { workspace = true, default-features = true }
-pem-rfc7468 = { git = "https://github.com/RustCrypto/formats" }
+pem-rfc7468 = { workspace = true, default-features = true }
 ring-compat = { workspace = true, default-features = true, features = ["std"] }
 sha2 = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
-x509-cert = { git = "https://github.com/RustCrypto/formats", features = ["pem", "std"] }
+x509-cert = { workspace = true, default-features = true, features = ["pem"] }

--- a/dice-cert-check/Cargo.toml
+++ b/dice-cert-check/Cargo.toml
@@ -10,16 +10,16 @@ edition = "2021"
 #   PEM encoded certs. This has been fixed on the development branch but
 #   hasn't made it into a release yet.
 [dependencies]
-anyhow = "1.0.68"
-clap = { version = "4.1.4", features = ["derive"] }
+anyhow = { workspace = true, default-features = true }
+clap = { workspace = true, default-features = true, features = ["derive"] }
 const-oid = { git = "https://github.com/RustCrypto/formats" }
-ecdsa = "0.16"
-env_logger = "0.10.0"
-hex = "0.4.3"
-log = "0.4.17"
-p384 = "0.12.0"
+env_logger = { workspace = true, default-features = true }
+ecdsa = { workspace = true, default-features = true }
+hex = { workspace = true, default-features = true }
+log = { workspace = true, default-features = true, features = ["std"] }
+p384 = { workspace = true, default-features = true }
 pem-rfc7468 = { git = "https://github.com/RustCrypto/formats" }
-ring-compat = { version = "0.6.0", features = ["std"] }
-sha2 = "0.10.6"
-thiserror = "1.0.38"
+ring-compat = { workspace = true, default-features = true, features = ["std"] }
+sha2 = { workspace = true, default-features = true }
+thiserror = { workspace = true, default-features = true }
 x509-cert = { git = "https://github.com/RustCrypto/formats", features = ["pem", "std"] }

--- a/dice-cert-check/src/main.rs
+++ b/dice-cert-check/src/main.rs
@@ -118,7 +118,7 @@ fn convert(
 
     // this is a bit weird, but there's a reason ...
     let cert_vec = match encoding {
-        Encoding::DER => cert.to_vec()?,
+        Encoding::DER => cert.to_der()?,
         // If we get the PEM encoded cert by just calling 'to_vec' it will
         // be preceded by 5 bytes of ... something not PEM. We work around
         // this by calling 'as_bytes' first.
@@ -166,7 +166,7 @@ fn verify(cert_chain: &[Certificate]) -> Result<()> {
     )?;
     debug!("Initial signature: {}", signature);
 
-    let message = cert_chain[0].tbs_certificate.to_vec()?;
+    let message = cert_chain[0].tbs_certificate.to_der()?;
     debug!("Initial message: {}", message.encode_hex::<String>());
 
     _verify(&cert_chain[1..], &message, &signature)
@@ -198,7 +198,7 @@ fn _verify(
         &cert_chain[0].signature_algorithm,
         &cert_chain[0].signature,
     )?;
-    let message = cert_chain[0].tbs_certificate.to_vec()?;
+    let message = cert_chain[0].tbs_certificate.to_der()?;
 
     if cert_chain.len() > 1 {
         _verify(&cert_chain[1..], &message, &signature)

--- a/dice-mfg/Cargo.toml
+++ b/dice-mfg/Cargo.toml
@@ -6,7 +6,7 @@ description = "A command line tool for creating and programming device identitie
 license = "MPL-2.0"
 
 [dependencies]
-anyhow.workspace = true
+anyhow = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["clock", "std"] }
 clap = { workspace = true, features = ["derive", "env"] }
 const-oid = { version = "0.9.2", features = ["std", "db"] }


### PR DESCRIPTION
progress on #91: Update `dice-cert-check` to use workspace dependencies. The hard part of this was getting it to use releases for  `const-oid`, `pem-rfc7468` and `x509-cert`.

