### PR TITLE
Fix issue with features specified for anyhow, clap, and pem.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,33 +242,31 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.14"
+version = "4.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906f7fe1da4185b7a282b2bc90172a496f9def1aca4545fe7526810741591e14"
+checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.1.14"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351f9ad9688141ed83dfd8f5fb998a06225ef444b48ff4dc43de6d409b7fd10b"
+checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
 dependencies = [
- "bitflags 1.3.2",
+ "anstream",
+ "anstyle",
  "clap_lex",
- "is-terminal",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.14"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d7dc0031c3a59a04fc2ba395c8e2dd463cba1859275f065d225f6122221b45"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -230,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "cmac"
@@ -244,6 +290,12 @@ dependencies = [
  "dbl",
  "digest",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "const-oid"
@@ -1374,6 +1426,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
 chrono = { version = "0.4.31", default-features=false }
-clap = { version = "4", default-features = false }
+clap = { version = "4.4", features = ["derive", "env"] }
 corncobs = "0.1"
 derive_more = "0.99"
 ecdsa = { version = "0.16", default-features = false }
 env_logger = { version = "0.10", default-features = false }
-hex = { version = "0.4", default-features = false }
+hex.version = "0.4"
 hubpack = "0.1"
 log = { version = "0.4", features = ["std"] }
 p384 = { version = "0.13", default-features = false }

--- a/dice-cert-check/Cargo.toml
+++ b/dice-cert-check/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = { workspace = true, default-features = true }
-clap = { workspace = true, default-features = true, features = ["derive"] }
+anyhow = { workspace = true, features = ["std"] }
+clap.workspace = true
 const-oid = { version = "0.9.5", features = ["db"] }
 env_logger = { workspace = true, default-features = true }
 hex = { workspace = true, default-features = true }

--- a/dice-cert-tmpl/Cargo.toml
+++ b/dice-cert-tmpl/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-clap = { workspace = true, features = ["derive"] }
+clap.workspace = true
 dice-mfg-msgs = { path = "../dice-mfg-msgs" }
 pem = { workspace = true, default-features = true }
 salty.workspace = true

--- a/dice-mfg/Cargo.toml
+++ b/dice-mfg/Cargo.toml
@@ -8,13 +8,13 @@ license = "MPL-2.0"
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["clock", "std"] }
-clap = { workspace = true, features = ["derive", "env"] }
+clap.workspace = true
 const-oid = { version = "0.9.5", features = ["std", "db"] }
 corncobs.workspace = true
 dice-mfg-msgs = { path = "../dice-mfg-msgs", features = ["std"] }
 env_logger.workspace = true
 log.workspace = true
-pem.workspace = true
+pem = { workspace = true, features = ["std"] }
 rpassword.workspace = true
 serde_json.workspace = true
 serialport.workspace = true

--- a/yhsm-audit/Cargo.toml
+++ b/yhsm-audit/Cargo.toml
@@ -3,10 +3,8 @@ name = "yubihsm-audit"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-anyhow.workspace = true
+anyhow = { workspace = true, features = ["std"] }
 clap.workspace = true
 derive_more.workspace = true
 env_logger.workspace = true


### PR DESCRIPTION
I don't fully understand how cargo resolves dependencies & features but `cargo build --project` was failing due to missing features in the crates listed above. These were not explicitly set in their respective `Cargo.toml` files so this commit resolves that.