### PR TITLE
attest-data: Remove dependency on ed25519-dalek, use salty instead.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,8 +116,8 @@ checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 name = "attest-data"
 version = "0.1.0"
 dependencies = [
- "ed25519-dalek",
  "hubpack",
+ "salty",
  "serde",
  "serde_with",
  "sha3",

--- a/attest-data/Cargo.toml
+++ b/attest-data/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 hubpack.workspace = true
-ed25519-dalek.workspace = true
 thiserror = { workspace = true, optional = true }
+salty.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true, features = ["macros"] }
 sha3.workspace = true

--- a/attest-data/src/lib.rs
+++ b/attest-data/src/lib.rs
@@ -4,8 +4,8 @@
 
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 
-use ed25519_dalek::{Signature, SignatureError, SIGNATURE_LENGTH};
 use hubpack::SerializedSize;
+use salty::constants::SIGNATURE_SERIALIZED_LENGTH;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use sha3::{
@@ -57,7 +57,7 @@ pub const NONCE_SIZE: usize = SHA3_256_DIGEST_SIZE;
 pub type Sha3_256Digest = ArrayBuf<SHA3_256_DIGEST_SIZE>;
 
 /// An array of bytes sized appropriately for a sha3-256 digest.
-pub type Ed25519Signature = ArrayBuf<SIGNATURE_LENGTH>;
+pub type Ed25519Signature = ArrayBuf<SIGNATURE_SERIALIZED_LENGTH>;
 
 /// Nonce is a newtype around an appropriately sized byte array.
 pub type Nonce = ArrayBuf<NONCE_SIZE>;
@@ -127,14 +127,4 @@ impl<const N: usize> Default for Log<N> {
 #[derive(Deserialize, Serialize, SerializedSize)]
 pub enum Attestation {
     Ed25519(Ed25519Signature),
-}
-
-impl TryFrom<&Attestation> for Signature {
-    type Error = SignatureError;
-
-    fn try_from(attestation: &Attestation) -> Result<Self, Self::Error> {
-        match attestation {
-            Attestation::Ed25519(s) => Ok(Signature::from_bytes(&s.0)),
-        }
-    }
 }

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -488,7 +488,9 @@ fn main() -> Result<()> {
                 hubpack::deserialize(&attestation).map_err(|e| {
                     anyhow!("Failed to deserialize Attestation: {}", e)
                 })?;
-            let signature = Signature::try_from(&attestation)?;
+            let signature = match attestation {
+                Attestation::Ed25519(s) => Signature::from_bytes(&s.0),
+            };
 
             // - log_data: the hubpack encoded measurement log `hubpack(log)`
             let log = fs::read(log)?;


### PR DESCRIPTION
The current version of curve25519-dalek uses rust features that aren't available in the compiler version pinned by hubris. Since we're only using one type and one constant from dalek it's easily replaced by the salty crate.