### PR TITLE
manufacture: `intermediate-cert` param is now required

### DIFF
--- a/dice-mfg/src/main.rs
+++ b/dice-mfg/src/main.rs
@@ -86,7 +86,7 @@ enum Command {
 
         /// Path to intermediate cert to send.
         #[clap(long, env)]
-        intermediate_cert: Option<PathBuf>,
+        intermediate_cert: PathBuf,
 
         /// Platform identity string
         #[clap(value_parser = validate_pid, env = "DICE_MFG_PLATFORM_ID")]
@@ -312,9 +312,6 @@ fn main() -> Result<()> {
             if !dice_mfg::check_csr(&csr, &platform_id)? {
                 bail!("CSR does not meet policy requirements");
             }
-
-            let intermediate_cert = intermediate_cert
-                .unwrap_or_else(|| ca_root.join("ca.cert.pem"));
 
             if intermediate_cert.is_file() {
                 driver.set_intermediate_cert(&intermediate_cert)?;


### PR DESCRIPTION
Previously if this param was omitted the `manufacture` command would attempt to find the intermediate CA cert in the place the `oks` software stores it by convention. This was the right thing to do for FCS but now that we're attempting to support multiple CA interfaces this behavior requires knowledge of not just openssl but the specific configuration and filesystem structure created by OKS.

This commit makes this parameter required removing the OKS / openssl specific knowledge from the `manufacture` command / interface. This will break consumers that relied on the old default behavior. This param will be required until we implement a mechanism to get this info from the CAs we support.