### PR TITLE
Add structure to support CAs beyond `openssl ca`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,9 +493,12 @@ dependencies = [
  "log",
  "pem-rfc7468",
  "rpassword",
+ "serde",
+ "serde-keyvalue",
  "serde_json",
  "serialport",
  "sha3",
+ "shellexpand",
  "string-error",
  "tempfile",
  "x509-cert",
@@ -526,6 +529,27 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -804,6 +828,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "libudev"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +907,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +921,16 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -902,6 +953,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p256"
@@ -1011,6 +1068,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1115,17 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "remain"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9f2390298a947ee0aa6073d440e221c0726188cfbcdf9604addb6ee393eb4a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
 
 [[package]]
 name = "rfc6979"
@@ -1169,6 +1257,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-keyvalue"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2701d07ab4695b24a86b4a970431a6917f85473f500ccaf386f567da3957a7"
+dependencies = [
+ "nom",
+ "num-traits",
+ "remain",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1349,15 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest",
  "keccak",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde_with = { version = "3.6", default-features = false }
 serialport = { git = "https://github.com/jgallagher/serialport-rs", branch = "illumos-support" }
 sha2 = "0.10"
 sha3 = { version = "0.10", default-features = false }
+shellexpand = "3.1"
 string-error = "0.1"
 tempfile = { version = "3", default-features = false }
 thiserror = "1.0.57"

--- a/dice-mfg/Cargo.toml
+++ b/dice-mfg/Cargo.toml
@@ -16,9 +16,12 @@ env_logger.workspace = true
 log.workspace = true
 pem-rfc7468 = { workspace = true, features = ["alloc", "std"] }
 rpassword.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+serde-keyvalue.version = "0.1"
 serialport.workspace = true
 sha3.workspace = true
+shellexpand.workspace = true
 string-error.workspace = true
 tempfile.workspace = true
 x509-cert = { workspace = true, features = ["pem", "std"] }

--- a/dice-mfg/src/lib.rs
+++ b/dice-mfg/src/lib.rs
@@ -532,9 +532,22 @@ impl CertSigner {
             .unwrap_or(DEFAULT_ENGINE_SECTION.to_string());
 
         //canonicalize paths before we chdir
-        let openssl_cnf = fs::canonicalize(&self.openssl_cnf)?;
-        let csr_in = fs::canonicalize(csr_in)?;
-        let cert_out = std::path::absolute(cert_out)?;
+        let openssl_cnf =
+            fs::canonicalize(&self.openssl_cnf).with_context(|| {
+                format!(
+                    "failed to canonicalize path to OpenSSL config: {}",
+                    &self.openssl_cnf.display()
+                )
+            })?;
+        let csr_in = fs::canonicalize(csr_in).with_context(|| {
+            format!("failed to canonicalize path to CSR: {}", csr_in.display())
+        })?;
+        let cert_out = std::path::absolute(cert_out).with_context(|| {
+            format!(
+                "failed to make path to output cert absolute: {}",
+                cert_out.display()
+            )
+        })?;
         let lastpwd = env::current_dir()?;
         info!("setting pwd to: {}", self.ca_root.display());
         env::set_current_dir(&self.ca_root)?;


### PR DESCRIPTION
I spent some time banging my head against clap trying to get a better CLI for this and came up short. There's likely a way to accomplish this through the clap API but for now I'm just stuffing the config params required by each CA into a single `String` param that's formatted as key=value,....

this resolves #112 