### PR TITLE
Permslip signing backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,12 +493,9 @@ dependencies = [
  "log",
  "pem-rfc7468",
  "rpassword",
- "serde",
- "serde-keyvalue",
  "serde_json",
  "serialport",
  "sha3",
- "shellexpand",
  "string-error",
  "tempfile",
  "x509-cert",
@@ -529,27 +526,6 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -828,17 +804,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
-name = "libredox"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
-dependencies = [
- "bitflags 2.4.2",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
 name = "libudev"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,12 +872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,16 +880,6 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -953,12 +902,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p256"
@@ -1068,26 +1011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,17 +1038,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "remain"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9f2390298a947ee0aa6073d440e221c0726188cfbcdf9604addb6ee393eb4a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.52",
-]
 
 [[package]]
 name = "rfc6979"
@@ -1257,19 +1169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-keyvalue"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2701d07ab4695b24a86b4a970431a6917f85473f500ccaf386f567da3957a7"
-dependencies = [
- "nom",
- "num-traits",
- "remain",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,15 +1248,6 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest",
  "keccak",
-]
-
-[[package]]
-name = "shellexpand"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
-dependencies = [
- "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ serde_with = { version = "3.6", default-features = false }
 serialport = { git = "https://github.com/jgallagher/serialport-rs", branch = "illumos-support" }
 sha2 = "0.10"
 sha3 = { version = "0.10", default-features = false }
-shellexpand = "3.1"
 string-error = "0.1"
 tempfile = { version = "3", default-features = false }
 thiserror = "1.0.57"

--- a/dice-mfg/Cargo.toml
+++ b/dice-mfg/Cargo.toml
@@ -16,12 +16,9 @@ env_logger.workspace = true
 log.workspace = true
 pem-rfc7468 = { workspace = true, features = ["alloc", "std"] }
 rpassword.workspace = true
-serde.workspace = true
 serde_json.workspace = true
-serde-keyvalue.version = "0.1"
 serialport.workspace = true
 sha3.workspace = true
-shellexpand.workspace = true
 string-error.workspace = true
 tempfile.workspace = true
 x509-cert = { workspace = true, features = ["pem", "std"] }


### PR DESCRIPTION
~~NOTE: Depends on [permslip#165](https://github.com/oxidecomputer/permission-slip/pull/165); if you test locally, be sure to build `permslip` from that branch.~~

Reverts a few aspects of 26dae63f2c2bc6c026a505b1c938c3077daa8007, in particular the shell expansion and key-value encoding of arguments. Instead, we use a clap `Subcommand` for signing, which can be either `openssl` or `permslip`:
```
$ dice-mfg sign-cert --help                                        
Turn a CSR into a cert. This is a thin wrapper around either the `openssl ca` command (whose behavior will depend on the openssl.cnf provided by the caller), or `permslip sign` (whose behavior will be governed by a previously set key context and batch of approvals)

Usage: dice-mfg sign-cert [OPTIONS] --cert-out <CERT_OUT> <CSR_IN> <COMMAND>

Commands:
  openssl   
  permslip  
  help      Print this message or the help of the given subcommand(s)

Arguments:
  <CSR_IN>  Path to input CSR file [env: CSR_IN=]

Options:
      --cert-out <CERT_OUT>  Destination path for Cert [env: CERT_OUT=]
      --auth-id <AUTH_ID>    Auth ID used w/r YubiHSM [env: DICE_MFG_AUTH_ID=] [default: 2]
  -h, --help                 Print help
$ dice-mfg sign-cert openssl --help
Usage: dice-mfg sign-cert --cert-out <CERT_OUT> <CSR_IN> openssl [OPTIONS] --ca-root <CA_ROOT>

Options:
      --config <CONFIG>
          Path to openssl config file (typically openssl.cnf) used for signing operation [env: CONFIG=]
      --ca-section <CA_SECTION>
          CA section from openssl.cnf [env: CA_SECTION=]
      --v3-section <V3_SECTION>
          x509 v3 extension section from openssl.cnf [env: V3_SECTION=]
      --engine-section <ENGINE_SECTION>
          Engine section from openssl.cnf [env: ENGINE_SECTION=]
      --ca-root <CA_ROOT>
          Root directory for CA state. If provided the tool will chdir to this directory before executing openssl commands. This is intended to support openssl.cnf files that use relative paths [env: CA_ROOT=]
  -h, --help
          Print help
$ dice-mfg sign-cert permslip --help
Usage: dice-mfg sign-cert --cert-out <CERT_OUT> <CSR_IN> permslip <KEY_NAME>

Arguments:
  <KEY_NAME>  The name of the signing key

Options:
  -h, --help  Print help
```

Example with permslip batch approval:
```
$ dice-mfg sign-cert \                                                                                                             
    --cert-out=platform-id-request.crt.pem \                                                                      
    platform-id-request.csr.pem \                                          
    permslip 'Platform Identity TEST ONLY foo'
Error: Server responded: authorization failed, try `approve -- <request>`
$ permslip approve-batch \                                                                                                                                        
    --single-use \                                                                                                                           
    --constraints='C=US,O=Oxide Computer Company,CN=PDV2:PPP-PPPPPPP:RRR:SSSSSSSSSSS' \                                         
    -- sign 'Platform Identity TEST ONLY foo'
24905cc703492f8911e225fb66cd0f431e5397dc36b3c1be3b80b7bd499a97e802a355a972eaabddcbf3373d17ea2484cd3412daa1dd866366703476e59b0104
$ dice-mfg sign-cert \    
    --cert-out=platform-id-request.crt.pem \
    platform-id-request.csr.pem \                                                      
    permslip 'Platform Identity TEST ONLY foo'
Wrote to platform-id-request.crt.pem
$ openssl x509 -text -noout -in platform-id-request.crt.pem                                                                       
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            7d:99:c4:ad:e3:69:21:07:a0:8d:0d:4c:fa:cb:6c:5e:7e:3d:13:ff
        Signature Algorithm: ecdsa-with-SHA384
        Issuer: CN = Platform Identity TEST ONLY foo
        Validity
            Not Before: Mar 20 20:56:44 2024 GMT
            Not After : Dec 31 23:59:59 9999 GMT
        Subject: C = US, O = Oxide Computer Company, CN = PDV2:PPP-PPPPPPP:RRR:SSSSSSSSSSS
        Subject Public Key Info:
            Public Key Algorithm: ED25519
                ED25519 Public-Key:
                pub:
                    fa:f4:68:05:f9:96:9c:34:c1:ae:be:d1:02:61:41:
                    6a:9e:d8:29:7a:e7:2d:88:a0:33:fe:41:f8:70:db:
                    b7:24
        X509v3 extensions:
            X509v3 Subject Key Identifier: 
                57:44:C4:72:60:8C:E0:71:79:4E:43:8A:B4:EB:E1:94:2C:3F:49:94
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Key Usage: critical
                Certificate Sign, CRL Sign
            X509v3 Certificate Policies: critical
                Policy: 1.3.6.1.4.1.57551.1.3
                Policy: 2.23.133.5.4.100.6
                Policy: 2.23.133.5.4.100.8
                Policy: 2.23.133.5.4.100.12
    Signature Algorithm: ecdsa-with-SHA384
    Signature Value:
        30:65:02:31:00:83:33:de:0c:45:39:91:29:a0:aa:aa:70:04:
        27:7b:02:0d:07:4c:5b:1b:90:21:07:89:68:17:ed:52:b0:cd:
        9a:c4:ef:d0:54:72:2d:89:c8:e6:67:70:d6:69:70:57:ba:02:
        30:30:39:06:4b:d8:34:7d:d5:1a:32:f7:d2:90:85:bc:dd:c4:
        63:1c:e8:e2:63:4d:40:44:91:2c:d8:f4:a0:05:7e:e2:b9:da:
        a2:c3:8b:8a:e5:82:d7:dd:45:1b:a1:8d:9d
```