### PR TITLE
Allow callers to provide the permslip key name through the environment

### DIFF
--- a/dice-mfg/src/main.rs
+++ b/dice-mfg/src/main.rs
@@ -247,6 +247,7 @@ impl TryFrom<OpensslCaOptsRaw> for OpensslCaOpts {
 #[derive(Clone, Debug, Parser)]
 struct PermslipSigningOpts {
     /// The name of the signing key.
+    #[clap(env = "DICE_MFG_PERMSLIP_KEY")]
     key_name: String,
 }
 


### PR DESCRIPTION
`facade` prefers to use the environment to pass stuff