### PR TITLE
dice-mfg: bump version 0.1.1 -> 0.2.0

### DIFF
--- a/dice-mfg/Cargo.toml
+++ b/dice-mfg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dice-mfg"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "A command line tool for creating and programming device identities for Oxide RoTs."
 license = "MPL-2.0"


### PR DESCRIPTION
This is a minor version bump to reflect new features and incompatible changes w/ the 0.1.1 version.