### PR TITLE
Add `--locked` flag to CI test run.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,4 +23,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - run: sudo apt-get update
       - run: sudo apt-get install -y pkg-config libudev-dev
-      - run: cargo test --all-features
+      - run: cargo test --all-features --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "dice-mfg"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
This is what we wanted in the first place. It has the added benefit of causing an error if / when the Cargo.lock file gets updated and it shouldn't.