### PR TITLE
Rename `verifier` crate to `dice-verifier`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dice-verifier"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "attest-data",
+ "const-oid",
+ "ed25519-dalek",
+ "env_logger",
+ "log",
+ "p384",
+ "pem-rfc7468",
+ "sha3",
+ "x509-cert",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,22 +1461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "verifier"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "attest-data",
- "const-oid",
- "ed25519-dalek",
- "env_logger",
- "log",
- "p384",
- "pem-rfc7468",
- "sha3",
- "x509-cert",
-]
-
-[[package]]
 name = "verifier-cli"
 version = "0.1.0"
 dependencies = [
@@ -1468,6 +1468,7 @@ dependencies = [
  "attest-data",
  "clap",
  "const-oid",
+ "dice-verifier",
  "ed25519-dalek",
  "env_logger",
  "hubpack",
@@ -1476,7 +1477,6 @@ dependencies = [
  "pem-rfc7468",
  "sha3",
  "tempfile",
- "verifier",
  "x509-cert",
 ]
 

--- a/verifier-cli/Cargo.toml
+++ b/verifier-cli/Cargo.toml
@@ -18,5 +18,5 @@ p384 = { workspace = true, default-features = true }
 pem-rfc7468 = { workspace = true, features = ["alloc", "std"] }
 sha3.workspace = true
 tempfile.workspace = true
-verifier.path = "../verifier"
+dice-verifier.path = "../verifier"
 x509-cert = { workspace = true, default-features = true }

--- a/verifier-cli/src/main.rs
+++ b/verifier-cli/src/main.rs
@@ -5,6 +5,7 @@
 use anyhow::{anyhow, Context, Result};
 use attest_data::{Attestation, Nonce};
 use clap::{Parser, Subcommand, ValueEnum};
+use dice_verifier::PkiPathSignatureVerifier;
 use env_logger::Builder;
 use hubpack::SerializedSize;
 use log::{debug, error, info, warn, LevelFilter};
@@ -18,7 +19,6 @@ use std::{
     process::{Command, Output},
 };
 use tempfile::NamedTempFile;
-use verifier::PkiPathSignatureVerifier;
 use x509_cert::{
     der::{Decode, DecodePem},
     Certificate, PkiPath,
@@ -634,7 +634,7 @@ fn verify_attestation(
 
     let alias = Certificate::from_der(&alias)?;
 
-    verifier::verify_attestation(&alias, &attestation, &log, &nonce)
+    dice_verifier::verify_attestation(&alias, &attestation, &log, &nonce)
 }
 
 fn verify_cert_chain(

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "verifier"
+name = "dice-verifier"
 version = "0.1.0"
 edition = "2021"
 description = "a library crate implementing the attestation verifier"

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -161,6 +161,7 @@ impl CertVerifier for P384CertVerifier {
 }
 
 /// This struct encapsulates the signature verification process for a PkiPath.
+#[derive(Debug)]
 pub struct PkiPathSignatureVerifier {
     root_cert: Option<Certificate>,
 }


### PR DESCRIPTION
This makes it easier and more explicit to use as a library in other crates such as sprockets.