### PR TITLE
verifier-cli: Persist artifacts as json instead of raw binary.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,7 @@ dependencies = [
  "log",
  "p384",
  "pem-rfc7468",
+ "serde_json",
  "sha3",
  "tempfile",
  "x509-cert",

--- a/verifier-cli/Cargo.toml
+++ b/verifier-cli/Cargo.toml
@@ -20,3 +20,4 @@ sha3.workspace = true
 tempfile.workspace = true
 dice-verifier.path = "../verifier"
 x509-cert = { workspace = true, default-features = true }
+serde_json.workspace = true


### PR DESCRIPTION
This falls short of removing all binary encodings but it makes it possible for us to use the `verify` command to verify an attestation and persist the artifacts as JSON. Later we can use the `verify-attestation` and `verify-cert-chain` commands to re-verify the artifacts persisted by the `verify` command.

Other commands like `attest` and `log` still need to be updated to use the JSON encoding.