### PR TITLE
Consistent encoding

### DIFF
--- a/verifier-cli/README.md
+++ b/verifier-cli/README.md
@@ -51,14 +51,14 @@ $ cargo run --package verifier-cli -- cert-chain > cert-chain.pem
 ### Get the Measurement Log
 
 ```shell
-$ cargo run --package verifier-cli -- log > log.bin
+$ cargo run --package verifier-cli -- log > log.json
 ```
 
 ### Verify the Attestation
 
 ```shell
 $ cargo run --package verifier-cli -- cert 0 > alias.pem
-$ cargo run --package verifier-cli -- verify-attestation --alias-cert alias.pem --log log.bin --nonce nonce.bin attestation.json
+$ cargo run --package verifier-cli -- verify-attestation --alias-cert alias.pem --log log.json --nonce nonce.bin attestation.json
 ```
 
 ### Verify the cert chain

--- a/verifier-cli/README.md
+++ b/verifier-cli/README.md
@@ -37,7 +37,7 @@ configuration ... YMMV and all applicable disclaimers.
 
 ```shell
 $ dd if=/dev/urandom of=nonce.bin bs=32 count=1
-$ cargo run --package verifier-cli -- attest nonce.bin > attestation.bin
+$ cargo run --package verifier-cli -- attest nonce.bin > attestation.json
 ```
 
 ### Get the cert chain
@@ -58,7 +58,7 @@ $ cargo run --package verifier-cli -- log > log.bin
 
 ```shell
 $ cargo run --package verifier-cli -- cert 0 > alias.pem
-$ cargo run --package verifier-cli -- verify-attestation --alias-cert alias.pem --log log.bin --nonce nonce.bin attestation.bin
+$ cargo run --package verifier-cli -- verify-attestation --alias-cert alias.pem --log log.bin --nonce nonce.bin attestation.json
 ```
 
 ### Verify the cert chain

--- a/verifier-cli/src/main.rs
+++ b/verifier-cli/src/main.rs
@@ -564,11 +564,9 @@ fn verify<P: AsRef<Path>>(
     let nonce = Nonce::from_platform_rng()?;
 
     // write nonce to temp dir
-    let nonce_path = work_dir.as_ref().join("nonce.json");
+    let nonce_path = work_dir.as_ref().join("nonce.bin");
     info!("writing nonce to: {}", nonce_path.display());
-    let mut nonce_str = serde_json::to_string(&nonce)?;
-    nonce_str.push('\n');
-    fs::write(&nonce_path, nonce_str)?;
+    fs::write(&nonce_path, nonce)?;
 
     // get attestation
     info!("getting attestation");
@@ -647,8 +645,8 @@ fn verify_attestation(
         .map_err(|_| anyhow!("failed to serialize Log"))?;
     let log = buf;
 
-    let nonce = fs::read_to_string(nonce)?;
-    let nonce: Nonce = serde_json::from_str(&nonce)?;
+    let nonce = fs::read(nonce)?;
+    let nonce = Nonce::try_from(nonce)?;
 
     let alias = fs::read(alias_cert)?;
     let alias = match pem_rfc7468::decode_vec(&alias) {

--- a/verifier-cli/src/main.rs
+++ b/verifier-cli/src/main.rs
@@ -506,11 +506,15 @@ fn main() -> Result<()> {
             println!("{}", attest.cert_len(index)?)
         }
         AttestCommand::Log => {
-            let log_len = attest.log_len()?;
-            let mut out = vec![0u8; log_len as usize];
-            attest.log(&mut out)?;
+            let mut log = vec![0u8; attest.log_len()? as usize];
+            attest.log(&mut log)?;
 
-            io::stdout().write_all(&out)?;
+            let (log, _): (Log, _) = hubpack::deserialize(&log)
+                .map_err(|e| anyhow!("Failed to deserialize Log: {}", e))?;
+            let mut log = serde_json::to_string(&log)?;
+            log.push('\n');
+
+            io::stdout().write_all(log.as_bytes())?;
             io::stdout().flush()?;
         }
         AttestCommand::LogLen => println!("{}", attest.log_len()?),


### PR DESCRIPTION
This resolves two inconsistencies in the tool that made the instructions in the README inaccurate. The verification functions were updated to operate only on JSON encoded data. The `attest` and `log` commands still produced binary data however which prevented the verification command to operate on their output. This PR updates the `attest` and `log` commands to produce JSON.