### PR TITLE
Add explicit build step to build the workspace and no_std libs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,16 @@ name: test suite
 on: [push, pull_request]
 
 jobs:
+  build:
+    name: cargo build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y pkg-config libudev-dev
+      - run: cargo build --workspace
+      - run: cargo build --package attest-data --package dice-mfg-msgs
   clippy:
     name: cargo clippy
     runs-on: ubuntu-latest


### PR DESCRIPTION
The resolver unifies features when building packages in the workspace. This prevents a single invocation of `cargo build --workspace` from building 'no_std' versions of the libraries here. Adding an explicit build command for our libraries that have 'std' features ensures that we catch errors that break the build if 'std' is not enabled.