### PR TITLE
dice-mfg-msgs: Impliment PlatformId::TryFrom<&PkiPath>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,11 +509,14 @@ dependencies = [
 name = "dice-mfg-msgs"
 version = "0.2.1"
 dependencies = [
+ "anyhow",
+ "const-oid",
  "corncobs",
  "hubpack",
  "serde",
  "serde-big-array",
  "thiserror 2.0.12",
+ "x509-cert",
  "zerocopy",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,7 +1511,7 @@ dependencies = [
  "anyhow",
  "attest-data",
  "clap",
- "const-oid",
+ "dice-mfg-msgs",
  "dice-verifier",
  "ed25519-dalek",
  "env_logger",

--- a/dice-mfg-msgs/Cargo.toml
+++ b/dice-mfg-msgs/Cargo.toml
@@ -4,12 +4,17 @@ version = "0.2.1"
 edition = "2021"
 
 [dependencies]
+const-oid = { workspace = true, optional = true }
 corncobs.workspace = true
 hubpack.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde-big-array.workspace = true
 thiserror = { workspace = true, optional = true }
+x509-cert = { workspace = true, optional = true }
 zerocopy.workspace = true
 
+[dev-dependencies]
+anyhow.workspace = true
+
 [features]
-std = ["thiserror"]
+std = ["const-oid/db", "thiserror", "x509-cert/pem", "x509-cert/std"]

--- a/verifier-cli/Cargo.toml
+++ b/verifier-cli/Cargo.toml
@@ -9,7 +9,7 @@ license = "MPL-2.0"
 anyhow = { workspace = true, features = ["std"] }
 attest-data = { path = "../attest-data", features = ["std"] }
 clap.workspace = true
-const-oid = { workspace = true, features = ["db"] }
+dice-mfg-msgs = { path = "../dice-mfg-msgs", features = ["std"] }
 ed25519-dalek = { workspace = true, features = ["std"] }
 env_logger.workspace = true
 hubpack.workspace = true


### PR DESCRIPTION
This is useful for pulling the PlatformId out of the cert chain produced by the RoT.