### PR TITLE
attest-data: enable `std` feature by default

### DIFF
--- a/attest-data/Cargo.toml
+++ b/attest-data/Cargo.toml
@@ -18,4 +18,5 @@ sha3.workspace = true
 static_assertions.workspace = true
 
 [features]
+default = ["std"]
 std = ["der/std", "der/derive", "der/oid", "getrandom", "hex", "rats-corim", "sha3/oid", "thiserror" ]


### PR DESCRIPTION
this will be the most common configuration