### PR TITLE
dice-verifier: Expose types `rats_corim::{Corim, Error}`

### DIFF
--- a/verifier/src/ipcc.rs
+++ b/verifier/src/ipcc.rs
@@ -6,7 +6,8 @@ use attest_data::{
     messages::{HostToRotCommand, RotToHost},
     Attestation, Log, Nonce,
 };
-use libipcc::{IpccError, IpccHandle};
+pub use libipcc::IpccError;
+use libipcc::IpccHandle;
 use x509_cert::{
     der::{self, Decode, Encode, Reader},
     Certificate, PkiPath,

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -10,7 +10,7 @@ use const_oid::db::{rfc5912::ID_EC_PUBLIC_KEY, rfc8410::ID_ED_25519};
 use hubpack::SerializedSize;
 #[cfg(feature = "ipcc")]
 use libipcc::IpccError;
-use rats_corim::Corim;
+pub use rats_corim::{Corim, Error as CorimError};
 use sha3::{Digest, Sha3_256};
 use std::collections::HashSet;
 use thiserror::Error;


### PR DESCRIPTION
These are part of our public API: we take `Corim` as input and produce the associated `rats_corim::Error` wrapped in our own.