### PR TITLE
attest-data: derive `Clone` for `Log`

### DIFF
--- a/attest-data/src/lib.rs
+++ b/attest-data/src/lib.rs
@@ -251,7 +251,7 @@ impl TryFrom<rats_corim::Digest> for Measurement {
 
 /// Log is the collection of measurements recorded
 #[serde_as]
-#[derive(Deserialize, Serialize, SerializedSize)]
+#[derive(Clone, Deserialize, Serialize, SerializedSize)]
 pub struct MeasurementLog<const N: usize> {
     index: u32,
     #[serde_as(as = "[_; N]")]


### PR DESCRIPTION
I'm working on a type to mock the attest trait and being able to clone the log will be a quality of life improvement