### PR TITLE
Add a mock implementation of the `Attest` trait.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,7 @@ dependencies = [
  "log",
  "p384",
  "rats-corim",
+ "serde_json",
  "sha3",
  "tempfile",
  "thiserror 2.0.12",

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -15,6 +15,7 @@ libipcc = { workspace = true, optional = true }
 log.workspace = true
 p384 = { workspace = true, default-features = true }
 rats-corim.workspace = true
+serde_json = { workspace = true, optional = true }
 sha3.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
@@ -22,3 +23,4 @@ x509-cert = { workspace = true, default-features = true }
 
 [features]
 ipcc = ["libipcc"]
+mock = ["ed25519-dalek/pem", "serde_json"]

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -25,6 +25,11 @@ use hiffy::AttestHiffyError;
 #[cfg(feature = "ipcc")]
 pub mod ipcc;
 
+#[cfg(feature = "mock")]
+pub mod mock;
+#[cfg(feature = "mock")]
+pub use mock::AttestMock;
+
 /// `AttestError` describes the possible errors encountered while getting an
 /// attestation from the RoT. Such errors range from those produced by the
 /// transport used to communicate with the RoT to those related to parsing

--- a/verifier/src/mock.rs
+++ b/verifier/src/mock.rs
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::{Attest, AttestError};
+use attest_data::{Attestation, Ed25519Signature, Log, Nonce};
+use ed25519_dalek::{
+    pkcs8::{self, DecodePrivateKey},
+    Signer, SigningKey,
+};
+use hubpack::SerializedSize;
+use sha3::{Digest, Sha3_256};
+use std::{fs, io, path::Path};
+use thiserror::Error;
+use x509_cert::{der, Certificate, PkiPath};
+
+#[derive(Debug, Error)]
+pub enum AttestMockError {
+    #[error("Failed to parse certificate: {0}")]
+    DerError(#[from] der::Error),
+    #[error("Failed to deserialize to JSON: {0}")]
+    Deserialize(#[from] serde_json::Error),
+    #[error("Failed to parse key from PKCS8: {0}")]
+    Pkcs8(#[from] pkcs8::Error),
+    #[error("Failed to read file from Path: {0}")]
+    IoError(#[from] io::Error),
+}
+
+pub struct AttestMock {
+    certs: PkiPath,
+    log: Log,
+    alias_key: SigningKey,
+}
+
+impl AttestMock {
+    pub fn load<P: AsRef<Path>, L: AsRef<Path>, A: AsRef<Path>>(
+        pki_path: P,
+        log_path: L,
+        alias_path: A,
+    ) -> Result<Self, AttestMockError> {
+        let certs = fs::read_to_string(pki_path)?;
+        let certs = Certificate::load_pem_chain(certs.as_bytes())?;
+
+        let log = fs::read_to_string(&log_path)?;
+        let log: Log = serde_json::from_str(&log)?;
+
+        let alias_key = SigningKey::read_pkcs8_pem_file(alias_path)?;
+
+        Ok(AttestMock {
+            certs,
+            log,
+            alias_key,
+        })
+    }
+}
+
+impl Attest for AttestMock {
+    fn get_measurement_log(&self) -> Result<Log, AttestError> {
+        Ok(self.log.clone())
+    }
+
+    fn get_certificates(&self) -> Result<PkiPath, AttestError> {
+        Ok(self.certs.clone())
+    }
+
+    fn attest(&self, nonce: &Nonce) -> Result<Attestation, AttestError> {
+        let mut buf = vec![0u8; Log::MAX_SIZE];
+        let len = hubpack::serialize(&mut buf, &self.log)
+            .map_err(AttestError::Serialize)?;
+
+        let mut digest = Sha3_256::new();
+        digest.update(&buf[..len]);
+        digest.update(nonce.as_ref());
+
+        let digest = digest.finalize();
+        let sig = self.alias_key.sign(&digest);
+
+        Ok(Attestation::Ed25519(Ed25519Signature::from(sig.to_bytes())))
+    }
+}


### PR DESCRIPTION
Mostly this just returns data that's populated when the type is instantiated. The only interesting code is in the `attest` function where we generate the attestation from the artifacts provided.