### PR TITLE
attest-mock: add tool to generate mock data used in the attestation API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,6 +50,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +69,12 @@ checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -131,10 +164,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "attest-mock"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "attest-data",
+ "clap",
+ "hex",
+ "hubpack",
+ "knuffel",
+ "miette",
+ "rats-corim",
+ "serde_json",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "base16ct"
@@ -234,6 +306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chumsky"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,7 +371,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim 0.11.0",
- "terminal_size",
+ "terminal_size 0.4.2",
 ]
 
 [[package]]
@@ -299,7 +380,7 @@ version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.99",
@@ -737,6 +818,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,15 +852,40 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -882,6 +994,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +1032,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "knuffel"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04bee6ddc6071011314b1ce4f7705fef6c009401dba4fd22cb0009db6a177413"
+dependencies = [
+ "base64 0.21.7",
+ "chumsky",
+ "knuffel-derive",
+ "miette",
+ "thiserror 1.0.58",
+ "unicode-width",
+]
+
+[[package]]
+name = "knuffel-derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91977f56c49cfb961e3d840e2e7c6e4a56bde7283898cf606861f1421348283d"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -990,6 +1146,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "is-terminal",
+ "miette-derive",
+ "once_cell",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size 0.1.17",
+ "textwrap",
+ "thiserror 1.0.58",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,10 +1213,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "p256"
@@ -1093,6 +1305,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1224,6 +1460,12 @@ dependencies = [
  "libc",
  "libusb1-sys",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc_version"
@@ -1420,6 +1662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,7 +1716,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1480,6 +1728,34 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f850c19edd184a205e883199a261ed44471c81e39bd95b1357f5febbef00e77a"
+dependencies = [
+ "is-terminal",
+]
 
 [[package]]
 name = "syn"
@@ -1517,12 +1793,33 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "terminal_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1628,6 +1925,24 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "dice-mfg-msgs",
     "yhsm-audit",
     "verifier-cli",
+    "attest-mock",
 ]
 resolver = "2"
 
@@ -24,8 +25,11 @@ env_logger = { version = "0.11.8", default-features = false }
 getrandom = "0.3.3"
 hex.version = "0.4"
 hubpack = "0.1"
+knuffel = "3.2.0"
 libipcc = { git = "https://github.com/oxidecomputer/ipcc-rs", rev = "524eb8f125003dff50b9703900c6b323f00f9e1b" }
 log = { version = "0.4.27", features = ["std"] }
+# pin miette to same version used by knuffel
+miette = { version = "5.10", features = ["fancy"] }
 p384 = { version = "0.13.1", default-features = false }
 pem-rfc7468 = { version = "0.7.0", default-features = false }
 rats-corim = { git = "https://github.com/flihp/rats-corim", branch = "minor-update-and-ergonomics" }

--- a/attest-mock/Cargo.toml
+++ b/attest-mock/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "attest-mock"
+version = "0.1.0"
+edition = "2024"
+description = "tools to generate attestation artifacts from KDL for use in testing"
+license = "MPL-2.0"
+
+[dependencies]
+anyhow = { workspace = true, features = ["std"] }
+attest-data = { path = "../attest-data", features = ["std"] }
+clap.workspace = true
+hex.workspace = true
+hubpack.workspace = true
+knuffel.workspace = true
+miette.workspace = true
+rats-corim.workspace = true
+serde_json.workspace = true

--- a/attest-mock/README.md
+++ b/attest-mock/README.md
@@ -1,0 +1,42 @@
+Testing often requires that we generate various artifacts used in the
+attestation API. It's possible to use a live system to generate these artifacts
+and then use them in testing but this doesn't give us much control: We can use
+them unmodified but that limits what we can test, or we can modify them by hand
+which is error prone and annoying.
+
+The alternative is to generate these artifacts from a specification. For
+complex structures like the cert chain this can be a lot of work (see
+[pki-playground](https://github.com/oxidecomputer/pki-playground)). The other
+structures are pretty simple though. This tool is intended to generate
+`attest_data::Log` and `rats_corim::Corim` instances from KDL documents.
+
+## example attest_data::Log KDL
+```kdl
+measurement {
+    algorithm "sha3-256"
+    digest "be4df4e085175f3de0c8ac4837e1c2c9a34e8983209dac6b549e94154f7cdd9c"
+}
+measurement {
+    algorithm "sha3-256"
+    digest "38e136aa11b0246211f36d8426702d90313f2a7dc50fa8a73d4e5007e70af3e3"
+}
+```
+
+## example rats_corim::Corim KDL
+```kdl
+vendor "example.com"
+tag-id "example-tag-id"
+id "example-id"
+
+measurement {
+    mkey "fwid-from-cert-chain"
+    algorithm 10
+    digest "be4df4e085175f3de0c8ac4837e1c2c9a34e8983209dac6b549e94154f7cdd9c"
+}
+
+measurement {
+    mkey "measurement-from-log"
+    algorithm 10
+    digest "38e136aa11b0246211f36d8426702d90313f2a7dc50fa8a73d4e5007e70af3e3"
+}
+```

--- a/attest-mock/src/corim.rs
+++ b/attest-mock/src/corim.rs
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use miette::{IntoDiagnostic, Result, miette};
+use rats_corim::CorimBuilder;
+
+#[derive(knuffel::Decode, Debug)]
+struct Measurement {
+    #[knuffel(child, unwrap(argument))]
+    pub mkey: String,
+
+    #[knuffel(child, unwrap(argument))]
+    pub algorithm: usize,
+
+    #[knuffel(child, unwrap(argument))]
+    pub digest: String,
+}
+
+#[derive(knuffel::Decode, Debug)]
+struct Document {
+    #[knuffel(child, unwrap(argument))]
+    pub vendor: String,
+
+    #[knuffel(child, unwrap(argument))]
+    pub tag_id: String,
+
+    #[knuffel(child, unwrap(argument))]
+    pub id: String,
+
+    #[knuffel(children)]
+    pub measurements: Vec<Measurement>,
+}
+
+/// Parse the KDL in from string `kdl`, convert it to an `rats_corim::Corim`
+/// instance. NOTE: The `name` param should be the name of the file that the
+/// `kdl` string was read from. This is used in error reporting.
+pub fn mock(name: &str, kdl: &str) -> Result<Vec<u8>> {
+    let doc: Document = knuffel::parse(name, kdl)?;
+
+    let mut corim_builder = CorimBuilder::new();
+    corim_builder.vendor(doc.vendor);
+    corim_builder.tag_id(doc.tag_id);
+    corim_builder.id(doc.id);
+
+    for measurement in doc.measurements {
+        let digest = hex::decode(measurement.digest)
+            .into_diagnostic()
+            .map_err(|e| miette!("decode digest hex: {e}"))?;
+        corim_builder.add_hash(measurement.mkey, measurement.algorithm, digest)
+    }
+
+    let corim = corim_builder
+        .build()
+        .into_diagnostic()
+        .map_err(|e| miette!("building CoRIM from config: {e}"))?;
+
+    corim
+        .to_vec()
+        .into_diagnostic()
+        .map_err(|e| miette!("CoRIM to bytes: {e}"))
+}

--- a/attest-mock/src/log.rs
+++ b/attest-mock/src/log.rs
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use attest_data::{Log, Sha3_256Digest};
+use hubpack::SerializedSize;
+use miette::{IntoDiagnostic, Result, miette};
+
+#[derive(knuffel::Decode, Debug)]
+struct Document {
+    #[knuffel(children)]
+    pub measurements: Vec<Measurement>,
+}
+
+#[derive(knuffel::Decode, Debug)]
+struct Measurement {
+    #[knuffel(child, unwrap(argument))]
+    pub algorithm: String,
+
+    #[knuffel(child, unwrap(argument))]
+    pub digest: String,
+}
+
+/// Parse the KDL in from string `kdl`, convert it to an `attest_data::Log`
+/// instance. NOTE: The `name` param should be the name of the file that the
+/// `kdl` string was read from. This is used in error reporting.
+pub fn mock(name: &str, kdl: &str) -> Result<Vec<u8>> {
+    let doc: Document = knuffel::parse(name, kdl)?;
+
+    let mut log = Log::default();
+    for measurement in doc.measurements {
+        let measurement = if measurement.algorithm == "sha3-256" {
+            let digest = hex::decode(measurement.digest)
+                .into_diagnostic()
+                .map_err(|e| miette!("decode digest hex: {e}"))?;
+            let digest =
+                Sha3_256Digest::try_from(digest).into_diagnostic().map_err(
+                    |e| miette!("decoded digest to Sha3_256Digest: {e}"),
+                )?;
+            attest_data::Measurement::Sha3_256(digest)
+        } else {
+            return Err(miette!(
+                "unsupported digest algorithm: {}",
+                measurement.algorithm
+            ));
+        };
+
+        log.push(measurement);
+    }
+
+    let mut out = vec![0u8; Log::MAX_SIZE];
+    let size = hubpack::serialize(&mut out, &log)
+        .into_diagnostic()
+        .map_err(|e| miette!("hubpack attest_data::Log: {e}"))?;
+    out.resize(size, 0);
+
+    Ok(out)
+}

--- a/attest-mock/src/main.rs
+++ b/attest-mock/src/main.rs
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use clap::{Parser, Subcommand};
+use miette::{IntoDiagnostic, Result, miette};
+use std::{
+    fs,
+    io::{self, Write},
+    path::PathBuf,
+};
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Structure to mock from KDL
+    #[command(subcommand)]
+    cmd: Command,
+
+    /// path to KDL file
+    kdl: PathBuf,
+}
+
+/// Known types
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Parse KDL describing rats_corim::Corim and produce CBOR encoded Corim
+    Corim,
+
+    /// Parse KDL describing attest_data::Log and produce hubpacked Log
+    Log,
+}
+
+mod corim;
+mod log;
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let name = args.kdl.to_string_lossy();
+    let kdl = fs::read_to_string(&args.kdl)
+        .into_diagnostic()
+        .map_err(|e| miette!("failed to read file {name} to string: {e}"))?;
+
+    let out = match args.cmd {
+        Command::Corim => corim::mock(&name, &kdl)?,
+        Command::Log => log::mock(&name, &kdl)?,
+    };
+
+    io::stdout()
+        .write_all(&out)
+        .into_diagnostic()
+        .map_err(|e| miette!("failed to write to stdout: {e}"))
+}


### PR DESCRIPTION
These are probably simple enough to be represented w/ TOML. The CoRIM could get complicated enough to warrant KDL but for now it feels like overkill.