### PR TITLE
attest-data: derive `Debug` on the `MeasurementLog` type

### DIFF
--- a/attest-data/src/lib.rs
+++ b/attest-data/src/lib.rs
@@ -251,7 +251,7 @@ impl TryFrom<rats_corim::Digest> for Measurement {
 
 /// Log is the collection of measurements recorded
 #[serde_as]
-#[derive(Clone, Deserialize, Serialize, SerializedSize)]
+#[derive(Clone, Debug, Deserialize, Serialize, SerializedSize)]
 pub struct MeasurementLog<const N: usize> {
     index: u32,
     #[serde_as(as = "[_; N]")]


### PR DESCRIPTION
useful in development / debugging