### PR TITLE
ci: Set permissions on GITHUB_TOKEN to the default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 name: test suite
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -1,5 +1,7 @@
 name: formatting
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   format:

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,5 +1,8 @@
 name: license-check
 on: pull_request
+permissions:
+  contents: read
+
 jobs:
   license:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,7 @@
 name: linters
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   clippy:


### PR DESCRIPTION
This repo is old enough that we get the old defaults which are permissive (read & write). This change manually sets the permissions to a minimal set as recommended by github.