### PR TITLE
dice-mfg-msgs: thiserror > 2 supports no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ sha3 = { version = "0.10.8", default-features = false }
 static_assertions = { version = "1.1.0", default-features = false }
 string-error = "0.1"
 tempfile = { version = "3.20.0", default-features = false }
-thiserror = "2.0.12"
+thiserror = { version = "2.0.12", default-features = false }
 x509-cert = { version = "0.2.5", default-features = false }
 yubihsm = { git = "https://github.com/oxidecomputer/yubihsm.rs", branch="v0.42.0-with-audit", features = ["default", "usb"] }
 zerocopy = "0.8.25"

--- a/dice-mfg-msgs/Cargo.toml
+++ b/dice-mfg-msgs/Cargo.toml
@@ -9,7 +9,7 @@ corncobs.workspace = true
 hubpack.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde-big-array.workspace = true
-thiserror = { workspace = true, optional = true }
+thiserror.workspace = true
 x509-cert = { workspace = true, optional = true }
 zerocopy.workspace = true
 
@@ -17,4 +17,4 @@ zerocopy.workspace = true
 anyhow.workspace = true
 
 [features]
-std = ["const-oid/db", "thiserror", "x509-cert/pem", "x509-cert/std"]
+std = ["const-oid/db", "x509-cert/pem", "x509-cert/std"]

--- a/dice-mfg-msgs/src/lib.rs
+++ b/dice-mfg-msgs/src/lib.rs
@@ -77,41 +77,16 @@ const CODE39_ALPHABET: [char; CODE39_LEN] = [
     'U', 'V', 'W', 'X', 'Y', 'Z', '-', '.', ' ', '$', '/', '+', '%',
 ];
 
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, thiserror::Error, PartialEq)]
 pub enum PlatformIdError {
-    #[cfg_attr(feature = "std", error("PID string length not supported"))]
+    #[error("PID string length not supported")]
     BadSize,
-    #[cfg_attr(feature = "std", error("invalid char '{c:?}' at offset {i:?}"))]
+    #[error("invalid char '{c:?}' at offset {i:?}")]
     Invalid { i: usize, c: char },
-    #[cfg_attr(feature = "std", error("PID string has invalid prefix"))]
+    #[error("PID string has invalid prefix")]
     InvalidPrefix,
-    #[cfg_attr(feature = "std", error("PID string is malformed"))]
+    #[error("PID string is malformed")]
     Malformed,
-}
-
-// `thiserror` is used to derive a `Display` impl when we have access to the
-// standard library. When we build for `no_std` we use this compatible
-// `Display` impl to satisfy the serde try_from container attribute used on the
-// `PlatformId` type.
-#[cfg(not(feature = "std"))]
-impl fmt::Display for PlatformIdError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            PlatformIdError::BadSize => {
-                write!(f, "PlatformId string is the wrong length")
-            }
-            PlatformIdError::Invalid { .. } => {
-                write!(f, "invalid character in PlatformId")
-            }
-            PlatformIdError::InvalidPrefix => {
-                write!(f, "Unknown prefix on PlatformId")
-            }
-            PlatformIdError::Malformed => {
-                write!(f, "PlatformId string contains non-UTF8 characters")
-            }
-        }
-    }
 }
 
 // see RFD 308 § 4.3.1
@@ -308,8 +283,7 @@ impl fmt::Display for PlatformId {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(any(test, feature = "std"), derive(thiserror::Error))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, thiserror::Error, PartialEq)]
 pub enum PlatformIdPkiPathError {
     #[error("Failed to decode CountryName")]
     CountryNameDecode(DerError),
@@ -388,19 +362,15 @@ pub enum KeySlotStatus {
     Revoked,
 }
 
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, thiserror::Error, PartialEq)]
 pub enum Error {
-    #[cfg_attr(feature = "std", error("Failed to decode corncobs message"))]
+    #[error("Failed to decode corncobs message")]
     Decode,
-    #[cfg_attr(
-        feature = "std",
-        error("Failed to deserialize hubpack message")
-    )]
+    #[error("Failed to deserialize hubpack message")]
     Deserialize,
-    #[cfg_attr(feature = "std", error("Failed to serialize hubpack message"))]
+    #[error("Failed to serialize hubpack message")]
     Serialize,
-    #[cfg_attr(feature = "std", error("Slice too large for SizedBuf"))]
+    #[error("Slice too large for SizedBuf")]
     SliceTooBig,
 }
 


### PR DESCRIPTION
This removes a lot of `#[cfg_attr(..)]` stuff as well as `fmt::Display` impls.