### PR TITLE
Return missing measurements if `verify_measurements` fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,7 @@ dependencies = [
  "const-oid",
  "ed25519-dalek",
  "env_logger",
+ "hex",
  "hubpack",
  "libipcc",
  "log",

--- a/attest-data/Cargo.toml
+++ b/attest-data/Cargo.toml
@@ -18,5 +18,6 @@ sha3.workspace = true
 static_assertions.workspace = true
 
 [features]
+testing = []
 default = ["std"]
 std = ["der/std", "der/derive", "der/oid", "getrandom", "hex", "rats-corim", "sha3/oid", "thiserror" ]

--- a/attest-data/src/lib.rs
+++ b/attest-data/src/lib.rs
@@ -192,6 +192,15 @@ pub enum Measurement {
     Sha3_256(Sha3_256Digest),
 }
 
+impl Measurement {
+    // This is useful for unit tesitng purposes. The name here
+    // intentional to indicate that this is unchecked and if you
+    // are using it anywhere besides unit tests something has gone wrong!
+    pub fn fake(bytes: [u8; 32]) -> Self {
+        Measurement::Sha3_256(Sha3_256Digest::try_from(bytes).unwrap())
+    }
+}
+
 impl Default for Measurement {
     fn default() -> Self {
         Measurement::Sha3_256(Sha3_256Digest::default())

--- a/attest-data/src/lib.rs
+++ b/attest-data/src/lib.rs
@@ -194,8 +194,9 @@ pub enum Measurement {
 
 impl Measurement {
     // This is useful for unit tesitng purposes. The name here
-    // intentional to indicate that this is unchecked and if you
+    // is intentional to indicate that this is unchecked and if you
     // are using it anywhere besides unit tests something has gone wrong!
+    #[cfg(any(test, feature = "testing"))]
     pub fn fake(bytes: [u8; 32]) -> Self {
         Measurement::Sha3_256(Sha3_256Digest::from(bytes))
     }

--- a/attest-data/src/lib.rs
+++ b/attest-data/src/lib.rs
@@ -197,7 +197,7 @@ impl Measurement {
     // intentional to indicate that this is unchecked and if you
     // are using it anywhere besides unit tests something has gone wrong!
     pub fn fake(bytes: [u8; 32]) -> Self {
-        Measurement::Sha3_256(Sha3_256Digest::try_from(bytes).unwrap())
+        Measurement::Sha3_256(Sha3_256Digest::from(bytes))
     }
 }
 

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -10,6 +10,7 @@ attest-data = { path = "../attest-data", features = ["std"] }
 const-oid.workspace = true
 ed25519-dalek = { workspace = true, features = ["std"] }
 env_logger.workspace = true
+hex = { workspace = true }
 hubpack.workspace = true
 libipcc = { workspace = true, optional = true }
 log.workspace = true

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -21,6 +21,11 @@ tempfile.workspace = true
 thiserror.workspace = true
 x509-cert = { workspace = true, default-features = true }
 
+
+[dev-dependencies]
+attest-data = { path = "../attest-data", features = ["std", "testing"] }
+
 [features]
+testing = []
 ipcc = ["libipcc"]
 mock = ["ed25519-dalek/pem"]


### PR DESCRIPTION
If we fail to verify the measurements it's useful to know which measurements were missing from the corpus. Return this information.