### PR TITLE
attest-data: make LOG_CAPACITY public

### DIFF
--- a/attest-data/src/lib.rs
+++ b/attest-data/src/lib.rs
@@ -328,7 +328,7 @@ impl<const N: usize> TryFrom<&[u8]> for MeasurementLog<N> {
     }
 }
 
-const LOG_CAPACITY: usize = 16;
+pub const LOG_CAPACITY: usize = 16;
 
 pub type Log = MeasurementLog<LOG_CAPACITY>;
 


### PR DESCRIPTION
I need to convert these types for the sled agent api and this helps to not hardcode random constants.