### PR TITLE
Reapply "attest-time: migrate simple benchmarking tools from vm-attes…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "attest-time"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "attest-data",
+ "clap",
+ "clap-verbosity",
+ "ctrlc",
+ "dice-verifier",
+ "env_logger",
+ "log",
+ "tokio",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +410,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -587,6 +611,17 @@ checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-verbosity"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7bf75a8e0407a558bd7e8e7919baa352e21fb0c1c7702a63c853f2277c4c63"
+dependencies = [
+ "clap",
+ "log",
+ "serde",
 ]
 
 [[package]]
@@ -800,6 +835,17 @@ checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
 dependencies = [
  "cfg-if",
  "memchr",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.3",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1112,6 +1158,18 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -2369,9 +2427,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdlpi-sys"
@@ -2693,6 +2751,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,6 +2854,21 @@ dependencies = [
 name = "nvpair-sys"
 version = "0.4.0"
 source = "git+https://github.com/jmesmon/rust-libzfs?branch=master#ecd5a922247a6c5acef55d76c5b8d115572bc850"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "object"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "attest-data",
     "attest-mock",
+    "attest-time",
     "barcode",
     "dice-cert-tmpl",
     "dice-mfg",
@@ -18,8 +19,10 @@ async-trait = "0.1.89"
 attest.path = "attest"
 chrono = { version = "0.4.42", default-features=false }
 clap = { version = "4.5.51", features = ["derive", "env"] }
+clap-verbosity = "2.1.0"
 const-oid = { version = "0.9.6", default-features = false }
 corncobs = "0.1"
+ctrlc = "3.5.1"
 der = { version = "0.7.10", default-features = false }
 ecdsa = { version = "0.16", default-features = false }
 ed25519-dalek = { version = "2.1", default-features = false }

--- a/attest-time/Cargo.toml
+++ b/attest-time/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "attest-time"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = { workspace = true, features = ["std"] }
+attest-data.path = "../attest-data"
+clap.workspace = true
+clap-verbosity.workspace = true
+ctrlc.workspace = true
+dice-verifier = { path = "../verifier" }
+env_logger.workspace = true
+log.workspace = true
+tokio = { workspace = true, features = ["full"] }
+
+[features]
+ipcc = ["dice-verifier/ipcc"]

--- a/attest-time/src/bin/m3vs.rs
+++ b/attest-time/src/bin/m3vs.rs
@@ -1,0 +1,179 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// This code implements Welford's method for calculating mean and variance
+// from streaming data as described here:
+// https://jonisalonen.com/2013/deriving-welfords-method-for-computing-variance/
+// The TLDR is:
+// variance(samples):
+//  M := 0
+//  S := 0
+//  for k from 1 to N:
+//    x := samples[k]
+//    oldM := M
+//    M := M + (x-M)/k
+//    S := S + (x-M)*(x-oldM)
+//  return S/(N-1)
+//
+//  where:
+//  - M is the mean
+//  - S is the squared distance from the mean
+
+use anyhow::{Context, Result, anyhow};
+use clap::Parser;
+use std::{
+    fs::File,
+    io::{self, BufRead, BufReader, Read},
+    path::PathBuf,
+};
+
+/// Read input samples formatted as a single sample per line. Each sample is
+/// an positive integer that can fit in a u32. This is the same format emitted
+/// by `attest-time`.
+#[derive(Debug, Parser)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// An optional input file. If omitted stdin will be read.
+    input: Option<PathBuf>,
+}
+
+/// This strcture holds data used to generate some measures of central
+/// tendency and dispersion
+struct Data {
+    /// `count` is a float because it's mostly used as the denominator in the
+    /// mean and variance calculation
+    count: u32,
+    /// collection used to collect input data
+    /// TODO: we can get rid of this once we're confident in our impl of the
+    /// Welford's algorithms
+    durations: Vec<u32>,
+    /// `max` is the running max for the dataset
+    max: u32,
+    /// `mean` holds the running mean calculated w/ Welford's method
+    mean: f64,
+    /// the running min for the dataset
+    min: u32,
+    /// `distance_2` is the running squared distance from the mean calculated
+    /// w/ Welford's method
+    distance_2: f64,
+}
+
+/// impl `Default` manually to set initial value for `min`
+impl Default for Data {
+    fn default() -> Self {
+        Self {
+            count: 0,
+            distance_2: 0.0,
+            max: 0,
+            mean: 0.0,
+            min: u32::MAX,
+            durations: Vec::new(),
+        }
+    }
+}
+
+/// my naive and expensive mean calculation
+fn mean(durations: &Vec<u32>, count: u32) -> Result<u32> {
+    let mut total: u128 = 0;
+    for v in durations {
+        // data in the durations collection is u32, this conversion is safe
+        total += *v as u128;
+    }
+
+    let mean = total / count as u128;
+    u32::try_from(mean).context("mean u128 to u32")
+}
+
+/// my naive and expensive variance calculation
+fn variance(durations: &Vec<u32>, count: u32, mean: u32) -> Result<u32> {
+    // accumulate sum of the squared difference between each sample and the mean
+    // this is the numerator in the classic variance equation
+    let mut variance: u128 = 0;
+    for v in durations {
+        let diff = *v as i128 - mean as i128;
+        let square = i128::pow(diff, 2);
+        variance += square as u128;
+    }
+
+    let variance = variance / count as u128 - 1;
+    Ok(variance as u32)
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // if args.input file not provided use stdin
+    let reader: Box<dyn Read> = match args.input {
+        Some(i) => Box::new(
+            File::open(&i)
+                .with_context(|| format!("open file: {}", i.display()))?,
+        ),
+        None => Box::new(io::stdin()),
+    };
+    let reader = BufReader::new(reader);
+
+    let mut data = Data::default();
+
+    for line in reader.lines() {
+        let line = line.context("read line")?;
+        let words: Vec<&str> = line.split_whitespace().collect();
+        if words.len() != 1 {
+            return Err(anyhow!("malformed line"));
+        }
+
+        let micros: u32 = words[0].parse().context("parse u32 from str")?;
+
+        if micros < data.min {
+            data.min = micros;
+        }
+
+        if micros > data.max {
+            data.max = micros;
+        }
+
+        data.count = data
+            .count
+            .checked_add(1)
+            .ok_or(anyhow!("too many samples: count overflow"))?;
+
+        data.durations.push(micros);
+
+        let micros = f64::from(micros);
+        let old_mean = data.mean;
+        data.mean = data.mean + (micros - data.mean) / (data.count as f64);
+        data.distance_2 += (micros - data.mean) * (micros - old_mean);
+    }
+
+    println!("sample count: {}", data.count);
+    println!("min: {}", data.min);
+    println!("max: {}", data.max);
+
+    // streaming mean, variance, & standard deviation
+    {
+        println!("welford's mean: {}", data.mean);
+
+        // final calculation from welford's method for variance
+        // return S/(n-1)
+        let variance = data.distance_2 / f64::from(data.count - 1);
+        println!("welford's variance: {}", variance);
+
+        println!("welford's standard deviation: {}", variance.sqrt());
+    }
+
+    // classic mean, variance, & standard deviation
+    {
+        let mean = mean(&data.durations, data.count)
+            .context("calculate mean from dataset")?;
+        println!("mean: {mean}");
+
+        let variance = variance(&data.durations, data.count, mean)
+            .context("calculate variance from dataset")?;
+        println!("variance: {variance}");
+
+        let sqrt = f64::from(variance).sqrt();
+        println!("standard deviation: {}", sqrt);
+    }
+
+    Ok(())
+}

--- a/attest-time/src/bin/sds-from-mean.rs
+++ b/attest-time/src/bin/sds-from-mean.rs
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use clap_verbosity::{InfoLevel, Verbosity};
+use log::debug;
+
+use std::{
+    collections::BTreeMap,
+    convert::TryFrom,
+    fs::File,
+    io::{self, BufRead, BufReader, Read},
+    path::PathBuf,
+};
+
+/// For each sample read from the provided file / `stdin`, calculate it's
+/// distance from the mean in units of the standard deviation. It then
+/// categorizes each sample into a z-score band and reports the number
+/// of samples that fall into each band to `stdout`.
+// Ex:
+// 0 10
+// 1 6
+// 3 9
+//
+// The numbers in the first column identify the band where:
+//
+// - `0` is for samples that fall within 1 standard deviation of the mean
+// - `1` '' between 1 and 2 ''
+// - `3` '' between 3 and 4 ''
+//
+// The numbers in the second column is the number of samples within each band
+//
+// Samples are read from the provided file or `stdin`.
+// Samples must be formatted as one u32 as base10 string per line.
+#[derive(Debug, Parser)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Dump debug output
+    #[command(flatten)]
+    verbose: Verbosity<InfoLevel>,
+
+    /// Calculate distance from this mean.
+    #[clap(long)]
+    mean: u32,
+
+    /// Stepping for distance calculation.
+    #[clap(long)]
+    std_dev: u32,
+
+    /// Path to file holding samples (or stdin if omitted).
+    #[clap(long)]
+    input: Option<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // if args.input file not provided use stdin
+    let reader: Box<dyn Read> = match args.input {
+        Some(i) => Box::new(
+            File::open(&i)
+                .with_context(|| format!("open file: {}", i.display()))?,
+        ),
+        None => Box::new(io::stdin()),
+    };
+    let reader = BufReader::new(reader);
+
+    env_logger::Builder::new()
+        .filter_level(args.verbose.log_level_filter())
+        .init();
+
+    // we only accept the `mean` input by the user as a u32 but we do signed
+    // arithmetic with it so this conversion is necessary
+    let mean = i32::try_from(args.mean).context("mean to i32")?;
+
+    // same for the `std-dev` but there's no checked conversion:
+    // https://internals.rust-lang.org/t/tryfrom-for-f64/9793
+    let std_dev = args.std_dev as f32;
+
+    let mut std_dev_map = BTreeMap::new();
+
+    for line in reader.lines() {
+        let line = line.context("read line")?;
+        let sample: i32 = line.parse().context("parse u32 from str")?;
+
+        let diff_abs = (mean - sample).abs();
+        let std_devs = (diff_abs as f32 / std_dev).trunc() as u32;
+
+        debug!(
+            "{sample} is {std_devs} std devs ({std_dev}) from the mean ({mean})"
+        );
+
+        if let Some(val) = std_dev_map.get_mut(&std_devs) {
+            *val += 1;
+        } else {
+            std_dev_map.insert(std_devs, 1);
+        }
+    }
+
+    for (std_devs, count) in std_dev_map.iter() {
+        println!("{std_devs} {count}");
+    }
+
+    Ok(())
+}

--- a/attest-time/src/main.rs
+++ b/attest-time/src/main.rs
@@ -1,0 +1,167 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+#[cfg(feature = "ipcc")]
+use dice_verifier::ipcc::AttestIpcc;
+use dice_verifier::{
+    Attest, Nonce,
+    hiffy::{AttestHiffy, AttestTask},
+};
+use std::{
+    fmt,
+    io::{self, Write},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::SystemTime,
+};
+
+#[derive(Clone, Debug, ValueEnum)]
+enum Interface {
+    #[cfg(feature = "ipcc")]
+    Ipcc,
+    Hiffy,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+enum Unit {
+    Milli,
+    Micro,
+    Nano,
+}
+
+impl fmt::Display for Unit {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Unit::Milli => write!(f, "ms"),
+            Unit::Micro => write!(f, "µs"),
+            Unit::Nano => write!(f, "ns"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+enum Commands {
+    Attest,
+    GetCertChains,
+    GetMeasurementLogs,
+}
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Command from the vm_attest_trait::AttestMock to sample.
+    #[clap(value_enum, long, default_value_t = Commands::Attest)]
+    command: Commands,
+
+    /// Number of samples to collect. If `None` then collect samples until
+    /// canceled.
+    #[clap(long)]
+    count: Option<usize>,
+
+    /// Interface used for communication with the Attest task.
+    #[clap(value_enum, long, default_value_t = Interface::Hiffy)]
+    interface: Interface,
+
+    /// Unit of time used for each sample
+    #[clap(value_enum, long, default_value_t = Unit::Nano)]
+    units: Unit,
+}
+
+/// This program gets an attestation through the mock VM attestation API. We
+/// get a timestamp from the system before and after. The caller can use this
+/// to roughtly determine the performance characteristics of this API / the
+/// underlying machinery.
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // set to `false` when terminated w/ Ctrl-C
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })
+    .context("set Ctrl-C handler")?;
+
+    // use stdout & `writeln!` so we can handle errors that would panic
+    // `println!`
+    let mut stdout = io::stdout().lock();
+
+    let attest: Box<dyn Attest> = match args.interface {
+        #[cfg(feature = "ipcc")]
+        Interface::Ipcc => Box::new(AttestIpcc::new()),
+        Interface::Hiffy => Box::new(AttestHiffy::new(AttestTask::Rot)),
+    };
+
+    // we do not care about the nonce, all 0's will require the same amount of
+    // work from the underlying impl
+    let nonce = Nonce::N32(attest_data::Array([0u8; 32]));
+
+    // time calls to `VmInstanceAttestMock::attest`, output duration in µs
+    let mut count: usize = 0;
+    while running.load(Ordering::SeqCst) {
+        let time = SystemTime::now();
+
+        match args.command {
+            Commands::Attest => {
+                let _ = attest
+                    .attest(&nonce)
+                    .await
+                    .context("get attestation from Attest impl")?;
+            }
+            Commands::GetCertChains => {
+                let _ = attest
+                    .get_certificates()
+                    .await
+                    .context("get cert chains from Attest impl")?;
+            }
+            Commands::GetMeasurementLogs => {
+                let _ = attest
+                    .get_measurement_log()
+                    .await
+                    .context("get measurement logs from Attest impl")?;
+            }
+        }
+
+        let elapsed = time
+            .elapsed()
+            .context("get elapsed time after attestation")?;
+
+        let duration = match args.units {
+            Unit::Milli => elapsed.as_millis(),
+            Unit::Micro => elapsed.as_micros(),
+            Unit::Nano => elapsed.as_nanos(),
+        };
+
+        // `writeln` returns `BrokenPipe` if we pipe output to another process
+        // and it closes its stdin (usually Ctrl-C). In this case we suppress
+        // the error and exit quietly
+        match writeln!(stdout, "{}", duration) {
+            Ok(_) => stdout.flush().context("flush stdout")?,
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::BrokenPipe {
+                    running.store(false, Ordering::SeqCst);
+                    eprintln!("stdout closed");
+                }
+            }
+        }
+
+        // break the loop if the caller has provided a `--count` & we've
+        // reached it
+        count = count.checked_add(1).context("add new 1 to count")?;
+        if let Some(max_count) = args.count
+            && max_count <= count
+        {
+            break;
+        }
+    }
+
+    stdout.flush().context("flush stdout")?;
+
+    Ok(())
+}


### PR DESCRIPTION
…t-proto"

This reverts commit 2ebe2af03f04950add1fb073cf5775a154e518aa.

And adds a fixup to the `attest-time` crate to disable ipcc by default. This is a work around for dependencies in a cargo workspace being unified: if we enable ipcc unconditionally or by default it looks like the other ELFs in the workspace will end up with libipcc `NEEDED` and that's not what we want.