### PR TITLE
attest-mock: refactor API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,21 +24,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,9 +235,8 @@ dependencies = [
  "hex",
  "hubpack",
  "knus",
- "miette",
  "rats-corim",
- "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -288,30 +272,6 @@ dependencies = [
  "pin-project-lite",
  "rand 0.8.5",
  "tokio",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "backtrace-ext"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -1748,12 +1708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,12 +2354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2743,16 +2691,8 @@ version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
- "backtrace",
- "backtrace-ext",
  "cfg-if",
  "miette-derive",
- "owo-colors",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
- "terminal_size",
- "textwrap",
  "unicode-width 0.1.14",
 ]
 
@@ -2772,15 +2712,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
 
 [[package]]
 name = "mio"
@@ -2981,15 +2912,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "omicron-common"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/omicron?rev=becbbb616f5f18b59cc42e511c148734c2ba3831#becbbb616f5f18b59cc42e511c148734c2ba3831"
@@ -3141,12 +3063,6 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "owo-colors"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "oxide-vpc"
@@ -4131,12 +4047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5076,27 +4986,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "supports-color"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
-dependencies = [
- "is_ci",
-]
-
-[[package]]
-name = "supports-hyperlinks"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
-
-[[package]]
-name = "supports-unicode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
-
-[[package]]
 name = "swrite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5223,16 +5112,6 @@ dependencies = [
  "quote",
  "structmeta",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
-dependencies = [
- "unicode-linebreak",
- "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5798,12 +5677,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ hubpack = "0.1"
 knus = "3.4.0"
 libipcc = { git = "https://github.com/oxidecomputer/ipcc-rs", rev = "7cdf2ab9c8d9e9267a8b366aa780c6c26f9a5ecf" }
 log = { version = "0.4.33", features = ["std"] }
-miette = { version = "7.6.0", features = ["fancy"] }
 p384 = { version = "0.13.1", default-features = false }
 pem-rfc7468 = { version = "1.0.0", default-features = false }
 rats-corim.git = "https://github.com/oxidecomputer/rats-corim"

--- a/attest-mock/Cargo.toml
+++ b/attest-mock/Cargo.toml
@@ -2,7 +2,7 @@
 name = "attest-mock"
 version = "0.1.0"
 edition = "2024"
-description = "tools to generate attestation artifacts from KDL for use in testing"
+description = "tools & library to generate attestation artifacts from KDL"
 license = "MPL-2.0"
 
 [dependencies]
@@ -12,6 +12,5 @@ clap.workspace = true
 hex.workspace = true
 hubpack.workspace = true
 knus.workspace = true
-miette.workspace = true
 rats-corim.workspace = true
-serde_json.workspace = true
+thiserror.workspace = true

--- a/attest-mock/src/corim.rs
+++ b/attest-mock/src/corim.rs
@@ -2,8 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use miette::{IntoDiagnostic, Result, miette};
 use rats_corim::CorimBuilder;
+
+use crate::{MockData, MockError};
 
 #[derive(knus::Decode, Debug)]
 pub struct Measurement {
@@ -18,7 +19,7 @@ pub struct Measurement {
 }
 
 #[derive(knus::Decode, Debug)]
-pub struct Document {
+pub struct MockCorim {
     #[knus(child, unwrap(argument))]
     pub vendor: String,
 
@@ -32,36 +33,48 @@ pub struct Document {
     pub measurements: Vec<Measurement>,
 }
 
-/// Parse the KDL in from string `kdl`
-///
-/// NOTE: The `name` param should be the name of the file that the
-/// `kdl` string was read from. This is used in error reporting.
-pub fn parse(name: &str, kdl: &str) -> Result<Document> {
-    let doc = knus::parse(name, kdl)?;
-    Ok(doc)
+#[derive(Debug, thiserror::Error)]
+pub enum MockCorimError {
+    #[error("Failed to decode hex from config: {hex_str}")]
+    HexDecode {
+        hex_str: String,
+        #[source]
+        err: hex::FromHexError,
+    },
+
+    #[error("CorimBuilder failed: {0}")]
+    CorimBuild(#[from] rats_corim::Error),
 }
 
-/// Convert `doc` to an `rats_corim::Corim` instance
-pub fn mock(doc: Document) -> Result<Vec<u8>> {
-    let mut corim_builder = CorimBuilder::new();
-    corim_builder.vendor(doc.vendor);
-    corim_builder.tag_id(doc.tag_id);
-    corim_builder.id(doc.id);
+impl MockData for MockCorim {
+    type Error = MockCorimError;
 
-    for measurement in doc.measurements {
-        let digest = hex::decode(measurement.digest)
-            .into_diagnostic()
-            .map_err(|e| miette!("decode digest hex: {e}"))?;
-        corim_builder.add_hash(measurement.mkey, measurement.algorithm, digest)
+    fn parse(name: &str, kdl: &str) -> Result<Self, MockError> {
+        Ok(knus::parse(name, kdl)?)
     }
 
-    let corim = corim_builder
-        .build()
-        .into_diagnostic()
-        .map_err(|e| miette!("building CoRIM from config: {e}"))?;
+    /// Produce a CoRIM document (serialized CBOR) from a `MockCorim` instance
+    fn to_bytes(&self) -> Result<Vec<u8>, Self::Error> {
+        let mut corim_builder = CorimBuilder::new();
+        corim_builder.vendor(self.vendor.clone());
+        corim_builder.tag_id(self.tag_id.clone());
+        corim_builder.id(self.id.clone());
 
-    corim
-        .to_vec()
-        .into_diagnostic()
-        .map_err(|e| miette!("CoRIM to bytes: {e}"))
+        for measurement in &self.measurements {
+            let digest = hex::decode(&measurement.digest).map_err(|e| {
+                Self::Error::HexDecode {
+                    hex_str: measurement.digest.clone(),
+                    err: e,
+                }
+            })?;
+            corim_builder.add_hash(
+                measurement.mkey.clone(),
+                measurement.algorithm,
+                digest,
+            )
+        }
+
+        let corim = corim_builder.build()?;
+        Ok(corim.to_vec()?)
+    }
 }

--- a/attest-mock/src/lib.rs
+++ b/attest-mock/src/lib.rs
@@ -2,5 +2,56 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::fs;
+use std::path::{Path, PathBuf};
+
 pub mod corim;
+pub use corim::{MockCorim, MockCorimError};
+
 pub mod log;
+pub use log::{MockLog, MockLogError};
+
+#[derive(Debug, thiserror::Error)]
+pub enum MockError {
+    #[error("Failed to parse the provided config: {0}")]
+    InvalidConfig(#[from] knus::errors::Error),
+
+    #[error("Failed to read file: {}", path.display())]
+    Load {
+        path: PathBuf,
+
+        #[source]
+        err: std::io::Error,
+    },
+}
+
+pub trait MockData {
+    type Error;
+
+    /// Load the KDL representation of the mock data
+    fn load<T: AsRef<Path>>(path: T) -> Result<Self, MockError>
+    where
+        Self: Sized,
+    {
+        let path_str = path.as_ref().to_string_lossy();
+        let kdl = fs::read_to_string(path_str.as_ref()).map_err(|e| {
+            MockError::Load {
+                path: PathBuf::from(path.as_ref()),
+                err: e,
+            }
+        })?;
+
+        Self::parse(&path_str, &kdl)
+    }
+
+    /// Parse the KDL in from string `kdl`
+    ///
+    /// NOTE: The `name` param should be the name of the file that the `kdl`
+    /// string was read from. This will show up in error reporting.
+    fn parse(name: &str, kdl: &str) -> Result<Self, MockError>
+    where
+        Self: Sized;
+
+    /// Produce a serialized byte stream representing the mock data
+    fn to_bytes(&self) -> Result<Vec<u8>, Self::Error>;
+}

--- a/attest-mock/src/log.rs
+++ b/attest-mock/src/log.rs
@@ -4,10 +4,11 @@
 
 use attest_data::{Log, Sha3_256Digest};
 use hubpack::SerializedSize;
-use miette::{IntoDiagnostic, Result, miette};
+
+use crate::{MockData, MockError};
 
 #[derive(knus::Decode, Debug)]
-pub struct Document {
+pub struct MockLog {
     #[knus(children)]
     pub measurements: Vec<Measurement>,
 }
@@ -21,43 +22,57 @@ pub struct Measurement {
     pub digest: String,
 }
 
-/// Parse the KDL in from string `kdl`
-///
-/// NOTE: The `name` param should be the name of the file that the
-/// `kdl` string was read from. This is used in error reporting.
-pub fn parse(name: &str, kdl: &str) -> Result<Document> {
-    let doc = knus::parse(name, kdl)?;
-    Ok(doc)
+#[derive(Debug, thiserror::Error)]
+pub enum MockLogError {
+    #[error("Unexpected algorithm string from config: {0}")]
+    BadAlgorithm(String),
+
+    #[error("Failed to convert digest from config to Sha3_256Digest: {0}")]
+    BadDigest(#[from] attest_data::AttestDataError),
+
+    #[error("Failed to decode hex from config: {hex_str}")]
+    HexDecode {
+        hex_str: String,
+        #[source]
+        err: hex::FromHexError,
+    },
+
+    #[error("Failed to serialize mock log to hubpack form: {0}")]
+    HubpackFail(#[from] hubpack::Error),
 }
 
-/// Convert `doc` to an `attest_data::Log` instance
-pub fn mock(doc: Document) -> Result<Vec<u8>> {
-    let mut log = Log::default();
-    for measurement in doc.measurements {
-        let measurement = if measurement.algorithm == "sha3-256" {
-            let digest = hex::decode(measurement.digest)
-                .into_diagnostic()
-                .map_err(|e| miette!("decode digest hex: {e}"))?;
-            let digest =
-                Sha3_256Digest::try_from(digest).into_diagnostic().map_err(
-                    |e| miette!("decoded digest to Sha3_256Digest: {e}"),
-                )?;
-            attest_data::Measurement::Sha3_256(digest)
-        } else {
-            return Err(miette!(
-                "unsupported digest algorithm: {}",
-                measurement.algorithm
-            ));
-        };
+impl MockData for MockLog {
+    type Error = MockLogError;
 
-        log.push(measurement);
+    fn parse(name: &str, kdl: &str) -> Result<Self, MockError> {
+        Ok(knus::parse(name, kdl)?)
     }
 
-    let mut out = vec![0u8; Log::MAX_SIZE];
-    let size = hubpack::serialize(&mut out, &log)
-        .into_diagnostic()
-        .map_err(|e| miette!("hubpack attest_data::Log: {e}"))?;
-    out.resize(size, 0);
+    fn to_bytes(&self) -> Result<Vec<u8>, Self::Error> {
+        let mut log = Log::default();
+        for measurement in &self.measurements {
+            let measurement = if measurement.algorithm == "sha3-256" {
+                let digest = hex::decode(&measurement.digest).map_err(|e| {
+                    Self::Error::HexDecode {
+                        hex_str: measurement.digest.clone(),
+                        err: e,
+                    }
+                })?;
+                let digest = Sha3_256Digest::try_from(digest)?;
+                attest_data::Measurement::Sha3_256(digest)
+            } else {
+                return Err(Self::Error::BadAlgorithm(
+                    measurement.algorithm.clone(),
+                ));
+            };
 
-    Ok(out)
+            log.push(measurement);
+        }
+
+        let mut out = vec![0u8; Log::MAX_SIZE];
+        let size = hubpack::serialize(&mut out, &log)?;
+        out.resize(size, 0);
+
+        Ok(out)
+    }
 }

--- a/attest-mock/src/main.rs
+++ b/attest-mock/src/main.rs
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use anyhow::Result;
 use clap::{Parser, Subcommand};
-use miette::{IntoDiagnostic, Result, miette};
 use std::{
-    fs,
     io::{self, Write},
     path::PathBuf,
 };
+
+use attest_mock::{MockCorim, MockData, MockLog};
 
 #[derive(Debug, Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -31,31 +32,19 @@ enum Command {
     Log,
 }
 
-mod corim;
-mod log;
-
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    let cow_name = args.kdl.to_string_lossy();
-    let name = cow_name.as_ref();
-    let kdl = fs::read_to_string(name)
-        .into_diagnostic()
-        .map_err(|e| miette!("failed to read file {name} to string: {e}"))?;
-
     let out = match args.cmd {
         Command::Corim => {
-            let doc = corim::parse(name, &kdl)?;
-            corim::mock(doc)?
+            let mock = MockCorim::load(&args.kdl)?;
+            mock.to_bytes()?
         }
         Command::Log => {
-            let doc = log::parse(name, &kdl)?;
-            log::mock(doc)?
+            let mock = MockLog::load(&args.kdl)?;
+            mock.to_bytes()?
         }
     };
 
-    io::stdout()
-        .write_all(&out)
-        .into_diagnostic()
-        .map_err(|e| miette!("failed to write to stdout: {e}"))
+    Ok(io::stdout().write_all(&out)?)
 }


### PR DESCRIPTION
This commit updates the API to use types instead of runctions & removes `miette` from the public interface.