### PR TITLE
attest-mock: refactor API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -250,9 +250,10 @@ dependencies = [
  "hex",
  "hubpack",
  "knus",
- "miette",
  "rats-corim",
- "serde_json",
+ "slog",
+ "slog-error-chain 0.1.0 (git+https://github.com/oxidecomputer/slog-error-chain?rev=15f69041f45774602108e47fb25e705dc23acfb2)",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -292,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -302,7 +303,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1753,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -3031,9 +3032,9 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -4243,9 +4244,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ hubpack = "0.1"
 knus = "3.4.0"
 libipcc = { git = "https://github.com/oxidecomputer/ipcc-rs", rev = "7cdf2ab9c8d9e9267a8b366aa780c6c26f9a5ecf" }
 log = { version = "0.4.33", features = ["std"] }
-miette = { version = "7.6.0", features = ["fancy"] }
 p384 = { version = "0.13.1", default-features = false }
 pem-rfc7468 = { version = "1.0.0", default-features = false }
 pki-playground = { git = "https://github.com/oxidecomputer/pki-playground", rev = "bcd3bf2dfe36468c494eac17463a4e10be366b35" }

--- a/attest-mock/Cargo.toml
+++ b/attest-mock/Cargo.toml
@@ -2,7 +2,7 @@
 name = "attest-mock"
 version = "0.1.0"
 edition = "2024"
-description = "tools to generate attestation artifacts from KDL for use in testing"
+description = "tools & library to generate attestation artifacts from KDL"
 license = "MPL-2.0"
 
 [dependencies]
@@ -12,6 +12,7 @@ clap.workspace = true
 hex.workspace = true
 hubpack.workspace = true
 knus.workspace = true
-miette.workspace = true
 rats-corim.workspace = true
-serde_json.workspace = true
+slog.workspace = true
+slog-error-chain = { workspace = true, features = ["derive"] }
+thiserror.workspace = true

--- a/attest-mock/src/corim.rs
+++ b/attest-mock/src/corim.rs
@@ -2,8 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use miette::{IntoDiagnostic, Result, miette};
-use rats_corim::CorimBuilder;
+use rats_corim::{Corim, CorimBuilder};
+use slog_error_chain::SlogInlineError;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use crate::MockData;
 
 #[derive(knus::Decode, Debug)]
 pub struct Measurement {
@@ -32,36 +38,84 @@ pub struct Document {
     pub measurements: Vec<Measurement>,
 }
 
-/// Parse the KDL in from string `kdl`
-///
-/// NOTE: The `name` param should be the name of the file that the
-/// `kdl` string was read from. This is used in error reporting.
-pub fn parse(name: &str, kdl: &str) -> Result<Document> {
-    let doc = knus::parse(name, kdl)?;
-    Ok(doc)
+pub struct MockCorim(Corim);
+
+#[derive(Debug, SlogInlineError, thiserror::Error)]
+pub enum MockCorimError {
+    #[error("CorimBuilder failed")]
+    CorimBuild(#[from] rats_corim::Error),
+
+    #[error("Failed to decode hex from config: {hex_str}")]
+    HexDecode {
+        hex_str: String,
+
+        #[source]
+        err: hex::FromHexError,
+    },
+
+    #[error("Failed to parse the provided config")]
+    InvalidConfig(#[from] knus::errors::Error),
+
+    #[error("Failed to read file: {}", path.display())]
+    Load {
+        path: PathBuf,
+
+        #[source]
+        err: std::io::Error,
+    },
 }
 
-/// Convert `doc` to an `rats_corim::Corim` instance
-pub fn mock(doc: Document) -> Result<Vec<u8>> {
-    let mut corim_builder = CorimBuilder::new();
-    corim_builder.vendor(doc.vendor);
-    corim_builder.tag_id(doc.tag_id);
-    corim_builder.id(doc.id);
+impl MockData for MockCorim {
+    type Error = MockCorimError;
+    type Inner = Corim;
 
-    for measurement in doc.measurements {
-        let digest = hex::decode(measurement.digest)
-            .into_diagnostic()
-            .map_err(|e| miette!("decode digest hex: {e}"))?;
-        corim_builder.add_hash(measurement.mkey, measurement.algorithm, digest)
+    /// Parse the contents of the provided file as a KDL document describing
+    /// a CoRIM document
+    fn load<T: AsRef<Path>>(path: T) -> Result<Self, Self::Error> {
+        let path_str = path.as_ref().to_string_lossy();
+        let kdl = fs::read_to_string(path_str.as_ref()).map_err(|e| {
+            MockCorimError::Load {
+                path: PathBuf::from(path.as_ref()),
+                err: e,
+            }
+        })?;
+
+        Self::parse(&path_str, &kdl)
     }
 
-    let corim = corim_builder
-        .build()
-        .into_diagnostic()
-        .map_err(|e| miette!("building CoRIM from config: {e}"))?;
+    /// Transform the provided KDL to a CoRIM document
+    fn parse(name: &str, kdl: &str) -> Result<Self, Self::Error> {
+        let doc: Document = knus::parse(name, kdl)?;
 
-    corim
-        .to_vec()
-        .into_diagnostic()
-        .map_err(|e| miette!("CoRIM to bytes: {e}"))
+        let mut corim_builder = CorimBuilder::new();
+        corim_builder.vendor(doc.vendor.clone());
+        corim_builder.tag_id(doc.tag_id.clone());
+        corim_builder.id(doc.id.clone());
+
+        for measurement in &doc.measurements {
+            let digest = hex::decode(&measurement.digest).map_err(|e| {
+                Self::Error::HexDecode {
+                    hex_str: measurement.digest.clone(),
+                    err: e,
+                }
+            })?;
+            corim_builder.add_hash(
+                measurement.mkey.clone(),
+                measurement.algorithm,
+                digest,
+            )
+        }
+
+        Ok(Self(corim_builder.build()?))
+    }
+
+    /// Serialize the CoRIM document to a vec of bytes
+    fn to_bytes(&self) -> Result<Vec<u8>, Self::Error> {
+        Ok(self.0.to_vec()?)
+    }
+
+    /// Pass ownership of the inner CoRIM instance to the caller
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
 }

--- a/attest-mock/src/lib.rs
+++ b/attest-mock/src/lib.rs
@@ -2,5 +2,34 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::path::Path;
+
 pub mod corim;
+pub use corim::{MockCorim, MockCorimError};
+
 pub mod log;
+pub use log::{MockLog, MockLogError};
+
+pub trait MockData {
+    type Error: std::error::Error + Send + Sync + 'static;
+    type Inner;
+
+    /// Load the KDL representation of the mock data
+    fn load<T: AsRef<Path>>(path: T) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+
+    /// Parse the KDL in from string `kdl`
+    ///
+    /// The `name` param should be the name of the file that the `kdl` string
+    /// was read from. This will show up in error reporting.
+    fn parse(name: &str, kdl: &str) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+
+    /// Produce a serialized representation of the mock data
+    fn to_bytes(&self) -> Result<Vec<u8>, Self::Error>;
+
+    /// Consume the instance and return ownership of Self::Inner
+    fn into_inner(self) -> Self::Inner;
+}

--- a/attest-mock/src/log.rs
+++ b/attest-mock/src/log.rs
@@ -4,7 +4,13 @@
 
 use attest_data::{Log, Sha3_256Digest};
 use hubpack::SerializedSize;
-use miette::{IntoDiagnostic, Result, miette};
+use slog_error_chain::SlogInlineError;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use crate::MockData;
 
 #[derive(knus::Decode, Debug)]
 pub struct Document {
@@ -21,43 +27,96 @@ pub struct Measurement {
     pub digest: String,
 }
 
-/// Parse the KDL in from string `kdl`
-///
-/// NOTE: The `name` param should be the name of the file that the
-/// `kdl` string was read from. This is used in error reporting.
-pub fn parse(name: &str, kdl: &str) -> Result<Document> {
-    let doc = knus::parse(name, kdl)?;
-    Ok(doc)
+pub struct MockLog(Log);
+
+#[derive(Debug, SlogInlineError, thiserror::Error)]
+pub enum MockLogError {
+    #[error("Unexpected algorithm string from config: {0}")]
+    BadAlgorithm(String),
+
+    #[error("Failed to convert digest from config to Sha3_256Digest")]
+    BadDigest(#[from] attest_data::AttestDataError),
+
+    #[error("Failed to decode hex from config: {hex_str}")]
+    HexDecode {
+        hex_str: String,
+
+        #[source]
+        err: hex::FromHexError,
+    },
+
+    #[error("Failed to serialize mock log to hubpack form")]
+    HubpackFail(#[from] hubpack::Error),
+
+    #[error("Failed to parse the provided config")]
+    InvalidConfig(#[from] knus::errors::Error),
+
+    #[error("Failed to read file: {}", path.display())]
+    Load {
+        path: PathBuf,
+
+        #[source]
+        err: std::io::Error,
+    },
 }
 
-/// Convert `doc` to an `attest_data::Log` instance
-pub fn mock(doc: Document) -> Result<Vec<u8>> {
-    let mut log = Log::default();
-    for measurement in doc.measurements {
-        let measurement = if measurement.algorithm == "sha3-256" {
-            let digest = hex::decode(measurement.digest)
-                .into_diagnostic()
-                .map_err(|e| miette!("decode digest hex: {e}"))?;
-            let digest =
-                Sha3_256Digest::try_from(digest).into_diagnostic().map_err(
-                    |e| miette!("decoded digest to Sha3_256Digest: {e}"),
-                )?;
-            attest_data::Measurement::Sha3_256(digest)
-        } else {
-            return Err(miette!(
-                "unsupported digest algorithm: {}",
-                measurement.algorithm
-            ));
-        };
+impl MockData for MockLog {
+    type Error = MockLogError;
+    type Inner = Log;
 
-        log.push(measurement);
+    /// Parse the contents of the provided file as a KDL document describing
+    /// a platform RoT Log
+    fn load<T: AsRef<Path>>(path: T) -> Result<Self, Self::Error> {
+        let path_str = path.as_ref().to_string_lossy();
+        let kdl = fs::read_to_string(path_str.as_ref()).map_err(|e| {
+            MockLogError::Load {
+                path: PathBuf::from(path.as_ref()),
+                err: e,
+            }
+        })?;
+
+        Self::parse(&path_str, &kdl)
     }
 
-    let mut out = vec![0u8; Log::MAX_SIZE];
-    let size = hubpack::serialize(&mut out, &log)
-        .into_diagnostic()
-        .map_err(|e| miette!("hubpack attest_data::Log: {e}"))?;
-    out.resize(size, 0);
+    /// Transform the provided KDL to a platform RoT Log
+    fn parse(name: &str, kdl: &str) -> Result<Self, Self::Error> {
+        let doc: Document = knus::parse(name, kdl)?;
 
-    Ok(out)
+        let mut log = Log::default();
+        for measurement in &doc.measurements {
+            let measurement = if measurement.algorithm == "sha3-256" {
+                let digest = hex::decode(&measurement.digest).map_err(|e| {
+                    Self::Error::HexDecode {
+                        hex_str: measurement.digest.clone(),
+                        err: e,
+                    }
+                })?;
+                let digest = Sha3_256Digest::try_from(digest)?;
+                attest_data::Measurement::Sha3_256(digest)
+            } else {
+                return Err(Self::Error::BadAlgorithm(
+                    measurement.algorithm.clone(),
+                ));
+            };
+
+            log.push(measurement);
+        }
+
+        Ok(Self(log))
+    }
+
+    /// Serialize the Log with hubpack to a vec of bytes
+    fn to_bytes(&self) -> Result<Vec<u8>, Self::Error> {
+        let mut out = vec![0u8; Log::MAX_SIZE];
+        let size = hubpack::serialize(&mut out, &self.0)?;
+        out.resize(size, 0);
+
+        Ok(out)
+    }
+
+    /// Consume the instance and return ownership of the inner platform RoT Log
+    /// to the caller
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
 }

--- a/attest-mock/src/main.rs
+++ b/attest-mock/src/main.rs
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use anyhow::Result;
 use clap::{Parser, Subcommand};
-use miette::{IntoDiagnostic, Result, miette};
 use std::{
-    fs,
     io::{self, Write},
     path::PathBuf,
 };
+
+use attest_mock::{MockCorim, MockData, MockLog};
 
 #[derive(Debug, Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -31,31 +32,19 @@ enum Command {
     Log,
 }
 
-mod corim;
-mod log;
-
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    let cow_name = args.kdl.to_string_lossy();
-    let name = cow_name.as_ref();
-    let kdl = fs::read_to_string(name)
-        .into_diagnostic()
-        .map_err(|e| miette!("failed to read file {name} to string: {e}"))?;
-
     let out = match args.cmd {
         Command::Corim => {
-            let doc = corim::parse(name, &kdl)?;
-            corim::mock(doc)?
+            let mock = MockCorim::load(&args.kdl)?;
+            mock.to_bytes()?
         }
         Command::Log => {
-            let doc = log::parse(name, &kdl)?;
-            log::mock(doc)?
+            let mock = MockLog::load(&args.kdl)?;
+            mock.to_bytes()?
         }
     };
 
-    io::stdout()
-        .write_all(&out)
-        .into_diagnostic()
-        .map_err(|e| miette!("failed to write to stdout: {e}"))
+    Ok(io::stdout().write_all(&out)?)
 }


### PR DESCRIPTION
This commit updates the API to use types instead of functions & removes `miette` from the public interface.