### PR TITLE
Use hiffy/idol calls directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,23 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli",
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "cpp_demangle",
+ "fallible-iterator",
+ "gimli 0.33.0",
+ "memmap2",
+ "object 0.39.1",
+ "rustc-demangle",
+ "smallvec 1.15.1",
+ "typed-arena",
 ]
 
 [[package]]
@@ -55,8 +71,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.12",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -184,6 +211,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +268,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -268,7 +331,23 @@ dependencies = [
  "dice-verifier",
  "env_logger",
  "log",
+ "slog",
+ "slog-async",
+ "slog-envlogger",
+ "slog-stdlog",
+ "slog-term",
  "tokio",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -297,11 +376,11 @@ version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
- "addr2line",
+ "addr2line 0.25.1",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.37.3",
  "rustc-demangle",
  "windows-link",
 ]
@@ -340,6 +419,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "basic-udev"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a45f9771ced8a774de5e5ebffbe520f52e3943bf5a9a6baa3a5d14a5de1afe6"
+
+[[package]]
 name = "bhyve_api"
 version = "0.0.0"
 source = "git+https://github.com/oxidecomputer/propolis?rev=8ccddb47a4c93b7e3480919495dae851afc83782#8ccddb47a4c93b7e3480919495dae851afc83782"
@@ -359,6 +444,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +479,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitfield"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ba6517c6b0f2bf08be60e187ab64b038438f22dd755614d8fe4d4098c46419"
+dependencies = [
+ "bitfield-macros",
+]
+
+[[package]]
+name = "bitfield-macros"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +511,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -413,6 +550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -473,9 +611,29 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "byteorder"
@@ -488,6 +646,15 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
 
 [[package]]
 name = "camino"
@@ -509,12 +676,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "capstone"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f442ae0f2f3f1b923334b4a5386c95c69c1cfa072bafa23d6fae6d9682eb1dd4"
+dependencies = [
+ "capstone-sys",
+ "static_assertions",
+]
+
+[[package]]
+name = "capstone-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e8087cab6731295f5a2a2bd82989ba4f41d3a428aab2e7c98d8f4db38aac05"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -524,6 +710,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -546,7 +734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.12",
 ]
 
@@ -558,7 +746,7 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20",
- "cipher",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -620,8 +808,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.6",
- "inout",
+ "inout 0.1.3",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -682,10 +880,16 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
  "dbl",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -693,6 +897,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cobs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd93fd2c1b27acd030440c9dbd9d14c1122aad622374fe05a670b67a4bc034be"
+dependencies = [
+ "heapless 0.9.3",
  "thiserror 2.0.18",
 ]
 
@@ -712,6 +926,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width 0.2.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +957,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -740,6 +981,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +1001,21 @@ name = "corncobs"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0e03e9489176ebd301922fdcd0234f6dee954cbf65311863353f20d2746a8db"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -768,6 +1034,42 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-any"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46db9f663dfb869b80fcf59e32d7a80fc6c464a4f6328f3f06a00f5e36d05f8c"
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -883,6 +1185,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,6 +1214,15 @@ dependencies = [
  "dispatch2",
  "nix 0.31.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -947,6 +1279,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
@@ -963,6 +1305,20 @@ checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core 0.23.0",
  "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -989,6 +1345,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
  "syn 2.0.118",
 ]
 
@@ -1021,6 +1388,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "datamap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc78156ab8e5328a2172df6a8afea26a985e82a514b71af1efd773962257cae5"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "dbl"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +1410,12 @@ name = "debug-ignore"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
+
+[[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "defmt"
@@ -1074,6 +1456,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "deku"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9711031e209dc1306d66985363b4397d4c7b911597580340b93c9729b55f6eb"
+dependencies = [
+ "bitvec",
+ "deku_derive",
+ "no_std_io2",
+ "rustversion",
+]
+
+[[package]]
+name = "deku_derive"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cb0719583cbe4e81fb40434ace2f0d22ccc3e39a74bb3796c22b451b4f139d"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1135,6 +1542,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "devinfo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb596a92f5b22f2ccd0f3dcaf11516ae8cff8b9f5448919893d561b4bfeb418"
+dependencies = [
+ "anyhow",
+ "libc",
+ "libdevinfo-sys",
+ "num_enum 0.7.5",
+]
+
+[[package]]
 name = "dice-cert-tmpl"
 version = "0.1.0"
 dependencies = [
@@ -1163,7 +1582,7 @@ dependencies = [
  "pem-rfc7468 1.0.0",
  "rpassword",
  "serde_json",
- "serialport",
+ "serialport 4.2.1-alpha.0",
  "sha3",
  "string-error",
  "tempfile",
@@ -1214,6 +1633,10 @@ dependencies = [
  "env_logger",
  "hex",
  "hubpack",
+ "humility-core",
+ "humility-hiffy",
+ "humility-idol",
+ "humility-probes-core",
  "libipcc",
  "log",
  "p384",
@@ -1250,6 +1673,8 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
+ "zeroize",
 ]
 
 [[package]]
@@ -1288,6 +1713,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "docsplay"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8547ea80db62c5bb9d7796fcce5e6e07d1136bdc1a02269095061e806758fab4"
+dependencies = [
+ "docsplay-macros",
+]
+
+[[package]]
+name = "docsplay-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11772ed3eb3db124d826f3abeadf5a791a557f62c19b123e3f07288158a71fdd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "dof"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,7 +1767,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "multer",
  "openapiv3",
  "paste",
@@ -1336,7 +1781,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "slog",
  "slog-async",
  "slog-bunyan",
@@ -1377,6 +1822,12 @@ dependencies = [
  "pest_derive",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1463,6 +1914,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1944,8 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
+ "anstream",
+ "anstyle",
  "env_filter",
  "log",
 ]
@@ -1515,6 +1974,54 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "esp-idf-part"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5ebc2381d030e4e89183554c3fcd4ad44dc5ab34961ab09e09b4adbe4f94b61"
+dependencies = [
+ "bitflags 2.10.0",
+ "csv",
+ "deku",
+ "md-5 0.10.6",
+ "parse_int",
+ "regex",
+ "serde",
+ "serde_plain",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "espflash"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5651fc2710ac2e1b1d0f26e19cb68899d05832bf82974acab04e37805499132"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.10.0",
+ "bytemuck",
+ "esp-idf-part",
+ "flate2",
+ "gimli 0.32.3",
+ "libc",
+ "log",
+ "md-5 0.11.0",
+ "miette",
+ "nix 0.31.3",
+ "object 0.39.1",
+ "serde",
+ "sha2 0.11.0",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -1549,6 +2056,17 @@ name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "fnv"
@@ -1599,6 +2117,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,6 +2169,16 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1732,8 +2266,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1757,6 +2293,23 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -1798,7 +2351,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1813,6 +2366,15 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1852,12 +2414,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -1886,12 +2481,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hidapi"
+version = "2.6.6"
+source = "git+https://github.com/oxidecomputer/hidapi-rs?branch=oxide-v2.6.6#74fcda94106181a4dca32370727b794011489afd"
+dependencies = [
+ "basic-udev",
+ "cc",
+ "cfg-if",
+ "libc",
+ "nix 0.30.1",
+ "pkg-config",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hif"
+version = "0.3.1"
+source = "git+https://github.com/oxidecomputer/hif#0e9a9d0774afe3c4eca5cb147fb64ad05d0bfcd8"
+dependencies = [
+ "pkg-version",
+ "postcard 0.7.3",
+ "serde",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -1901,6 +2520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1992,6 +2620,174 @@ dependencies = [
 ]
 
 [[package]]
+name = "hubtools"
+version = "0.4.9"
+source = "git+https://github.com/oxidecomputer/hubtools.git#5ea53d26576c5922534573ffd86d0108058a00e9"
+dependencies = [
+ "digest 0.11.3",
+ "hex",
+ "lpc55_areas",
+ "lpc55_sign",
+ "object 0.39.1",
+ "path-slash",
+ "rsa",
+ "thiserror 2.0.18",
+ "tlvc",
+ "tlvc-text",
+ "toml 1.1.3+spec-1.1.0",
+ "x509-cert",
+ "zerocopy",
+ "zip",
+]
+
+[[package]]
+name = "humility-arch-arm"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/humility?rev=80dae8d2af4d9ba34e583f17913780fe449aa9f0#80dae8d2af4d9ba34e583f17913780fe449aa9f0"
+dependencies = [
+ "capstone",
+ "num-derive",
+ "num-traits",
+]
+
+[[package]]
+name = "humility-core"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/humility?rev=80dae8d2af4d9ba34e583f17913780fe449aa9f0#80dae8d2af4d9ba34e583f17913780fe449aa9f0"
+dependencies = [
+ "addr2line 0.26.1",
+ "anyhow",
+ "auto_impl",
+ "bitfield",
+ "capstone",
+ "clap",
+ "datamap",
+ "gimli 0.33.0",
+ "goblin",
+ "hubpack",
+ "hubtools",
+ "humility-arch-arm",
+ "humility-log",
+ "humility_load_derive",
+ "humpty",
+ "idol",
+ "indexmap 2.14.0",
+ "indicatif",
+ "measurement-token",
+ "multimap",
+ "num-derive",
+ "num-traits",
+ "parse_int",
+ "rayon",
+ "regex",
+ "ron 0.12.2",
+ "rustc-demangle",
+ "scroll",
+ "serde",
+ "serde_json",
+ "strsim",
+ "thiserror 2.0.18",
+ "toml 1.1.3+spec-1.1.0",
+ "zerocopy",
+ "zip",
+]
+
+[[package]]
+name = "humility-doppel"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/humility?rev=80dae8d2af4d9ba34e583f17913780fe449aa9f0#80dae8d2af4d9ba34e583f17913780fe449aa9f0"
+dependencies = [
+ "anyhow",
+ "humility-core",
+ "indexmap 2.14.0",
+ "zerocopy",
+]
+
+[[package]]
+name = "humility-hiffy"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/humility?rev=80dae8d2af4d9ba34e583f17913780fe449aa9f0#80dae8d2af4d9ba34e583f17913780fe449aa9f0"
+dependencies = [
+ "anyhow",
+ "hif",
+ "humility-core",
+ "humility-doppel",
+ "humility-idol",
+ "idol",
+ "postcard 0.7.3",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "thiserror 2.0.18",
+ "zerocopy",
+]
+
+[[package]]
+name = "humility-idol"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/humility?rev=80dae8d2af4d9ba34e583f17913780fe449aa9f0#80dae8d2af4d9ba34e583f17913780fe449aa9f0"
+dependencies = [
+ "anyhow",
+ "hubpack",
+ "humility-core",
+ "idol",
+ "parse_int",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "humility-log"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/humility?rev=80dae8d2af4d9ba34e583f17913780fe449aa9f0#80dae8d2af4d9ba34e583f17913780fe449aa9f0"
+dependencies = [
+ "colored",
+ "slog",
+]
+
+[[package]]
+name = "humility-probes-core"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/humility?rev=80dae8d2af4d9ba34e583f17913780fe449aa9f0#80dae8d2af4d9ba34e583f17913780fe449aa9f0"
+dependencies = [
+ "anyhow",
+ "humility-arch-arm",
+ "humility-core",
+ "humpty",
+ "indicatif",
+ "measurement-token",
+ "num-derive",
+ "num-traits",
+ "nusb",
+ "parse_int",
+ "probe-rs",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "humility_load_derive"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/humility?rev=80dae8d2af4d9ba34e583f17913780fe449aa9f0#80dae8d2af4d9ba34e583f17913780fe449aa9f0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "humpty"
+version = "0.1.5"
+source = "git+https://github.com/oxidecomputer/humpty#c19ec79a6ae7f5618cd742106b845137942649df"
+dependencies = [
+ "hubpack",
+ "lzss",
+ "serde",
+ "serde-big-array",
+ "static_assertions",
+ "zerocopy",
+ "zerocopy-derive",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,7 +2814,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "pin-utils",
- "smallvec",
+ "smallvec 1.15.1",
  "tokio",
  "want",
 ]
@@ -2125,7 +2921,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec",
+ "smallvec 1.15.1",
  "zerovec",
 ]
 
@@ -2201,7 +2997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
- "smallvec",
+ "smallvec 1.15.1",
  "utf8_iter",
 ]
 
@@ -2214,6 +3010,28 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
+
+[[package]]
+name = "idol"
+version = "0.6.0"
+source = "git+https://github.com/oxidecomputer/idolatry.git#2c43ec5122030a4de12861bd7071e657f8d25b7f"
+dependencies = [
+ "indexmap 1.9.3",
+ "once_cell",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "ron 0.8.1",
+ "serde",
+ "serde_with",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ihex"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "365a784774bb381e8c19edb91190a90d7f2625e057b55de2bc0f6b57bc779ff2"
 
 [[package]]
 name = "illumos-devinfo"
@@ -2299,14 +3117,27 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -2359,12 +3190,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2 0.4.2",
+]
+
+[[package]]
+name = "io-kit-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d3a048d09fbb6597dbf7c69f40d14df4a49487db1487191618c893fc3b1c26"
+dependencies = [
+ "core-foundation-sys",
+ "mach2 0.5.0",
 ]
 
 [[package]]
@@ -2441,6 +3301,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jep106"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1354c92c91fd5595fd4cc46694b6914749cc90ea437246549c26b6ff0ec6d1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "jiff"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,6 +3348,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
 ]
 
 [[package]]
@@ -2546,10 +3425,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdevinfo-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92d2955daf279495d959fb506f3db6d17e2d62ab103f27c7d30be27a763cec1"
 
 [[package]]
 name = "libdlpi-sys"
@@ -2665,10 +3556,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lpc55_areas"
+version = "0.2.5"
+source = "git+https://github.com/oxidecomputer/lpc55_support#fc64732faf5511850b35f1734d572b9953d73374"
+dependencies = [
+ "bitfield",
+ "clap",
+ "packed_struct",
+ "serde",
+]
+
+[[package]]
+name = "lpc55_sign"
+version = "0.3.5"
+source = "git+https://github.com/oxidecomputer/lpc55_support#fc64732faf5511850b35f1734d572b9953d73374"
+dependencies = [
+ "byteorder",
+ "const-oid 0.9.6",
+ "crc-any",
+ "der",
+ "env_logger",
+ "hex",
+ "log",
+ "lpc55_areas",
+ "num-traits",
+ "packed_struct",
+ "pem-rfc7468 0.7.0",
+ "rsa",
+ "serde",
+ "serde-hex",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "x509-cert",
+ "zerocopy",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
+dependencies = [
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "lzss"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffcbd9e87fc27b574d4e37d4bf0d302828391f80ea3762dfce02d808fa257a01"
+dependencies = [
+ "void",
+]
 
 [[package]]
 name = "macaddr"
@@ -2698,6 +3643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "managed"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,6 +3662,37 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "measurement-token"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/lpc55_support#fc64732faf5511850b35f1734d572b9953d73374"
 
 [[package]]
 name = "memchr"
@@ -2794,6 +3779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2822,6 +3808,15 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2863,6 +3858,17 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -2887,6 +3893,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,7 +3919,8 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.6",
- "smallvec",
+ "serde",
+ "smallvec 1.15.1",
  "zeroize",
 ]
 
@@ -2940,9 +3962,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -2985,7 +4007,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -2998,6 +4020,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "nusb"
+version = "0.2.3"
+source = "git+https://github.com/oxidecomputer/nusb.git?branch=add_illumos#899ccceef9a50946e87a4af4d5615e18abfc41d9"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "devinfo",
+ "futures-core",
+ "io-kit-sys 0.5.0",
+ "libc",
+ "linux-raw-sys",
+ "log",
+ "once_cell",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3037,6 +4078,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -3119,9 +4183,9 @@ checksum = "e22821954cca73148cdd1547a540ac79a3f27b6d55b518490437bb9867212828"
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3141,7 +4205,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
 ]
@@ -3157,7 +4221,7 @@ dependencies = [
  "ingot",
  "kstat-macro",
  "opte-api",
- "postcard",
+ "postcard 1.1.3",
  "ref-cast",
  "serde",
  "tabwriter",
@@ -3173,7 +4237,7 @@ dependencies = [
  "illumos-sys-hdrs",
  "ingot",
  "ipnetwork",
- "postcard",
+ "postcard 1.1.3",
  "serde",
  "smoltcp",
 ]
@@ -3187,7 +4251,7 @@ dependencies = [
  "libnet",
  "opte",
  "oxide-vpc",
- "postcard",
+ "postcard 1.1.3",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -3266,6 +4330,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "packed_struct"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
+dependencies = [
+ "bitvec",
+ "packed_struct_codegen",
+ "serde",
+]
+
+[[package]]
+name = "packed_struct_codegen"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3284,7 +4376,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.5.18",
- "smallvec",
+ "smallvec 1.15.1",
  "windows-link",
 ]
 
@@ -3314,6 +4406,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse_int"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c464266693329dd5a8715098c7f86e6c5fd5d985018b8318f53d9c6c2b21a31"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,13 +4432,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3447,6 +4564,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "pkg-version"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e848f61ee4b2010345e65757e427a077213af1cee5d3e6a02e4a151dabca377"
+dependencies = [
+ "pkg-version-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "pkg-version-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1564bf5d476bf4a5eac420b88c500454c000dca79cef0a2e4304a1fe34361a3b"
+dependencies = [
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "pki-playground"
 version = "0.2.0"
 source = "git+https://github.com/oxidecomputer/pki-playground?rev=bcd3bf2dfe36468c494eac17463a4e10be366b35#bcd3bf2dfe36468c494eac17463a4e10be366b35"
@@ -3467,7 +4603,7 @@ dependencies = [
  "pkcs8",
  "rand 0.8.6",
  "rsa",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "sha3",
  "signature",
@@ -3481,6 +4617,20 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "poly1305"
@@ -3510,15 +4660,32 @@ dependencies = [
 
 [[package]]
 name = "postcard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
+dependencies = [
+ "heapless 0.7.17",
+ "postcard-cobs",
+ "serde",
+]
+
+[[package]]
+name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
 dependencies = [
- "cobs",
+ "cobs 0.3.0",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "serde",
 ]
+
+[[package]]
+name = "postcard-cobs"
+version = "0.1.5-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
 
 [[package]]
 name = "potential_utf"
@@ -3536,6 +4703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3551,12 +4724,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc83ee4a840062f368f9096d80077a9841ec117e17e7f700df81958f1451254"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "probe-rs"
+version = "0.31.0"
+source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide_v0.31.0#91d027e2bd786a4ec14e3b8bf3345ec52d08ca33"
+dependencies = [
+ "anyhow",
+ "async-io",
+ "bincode",
+ "bitfield",
+ "bitvec",
+ "cobs 0.5.1",
+ "docsplay",
+ "dunce",
+ "espflash",
+ "flate2",
+ "futures-lite",
+ "hidapi",
+ "ihex",
+ "itertools 0.14.0",
+ "jep106",
+ "nusb",
+ "object 0.38.1",
+ "parking_lot",
+ "probe-rs-target",
+ "rmp-serde",
+ "scroll",
+ "serde",
+ "serde_yaml",
+ "serialport 4.7.1-alpha.0",
+ "thiserror 2.0.18",
+ "tracing",
+ "uf2-decode",
+ "zerocopy",
+]
+
+[[package]]
+name = "probe-rs-target"
+version = "0.31.0"
+source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide_v0.31.0#91d027e2bd786a4ec14e3b8bf3345ec52d08ca33"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.14.0",
+ "jep106",
+ "serde",
+ "serde_with",
+ "url",
 ]
 
 [[package]]
@@ -3623,6 +4854,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -3693,7 +4930,7 @@ checksum = "b17e5363daa50bf1cccfade6b0fb970d2278758fd5cfa9ab69f25028e4b1afa3"
 dependencies = [
  "heck 0.5.0",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "openapiv3",
  "proc-macro2",
  "quote",
@@ -3715,7 +4952,7 @@ checksum = "90f6d9109b04e005bbdec84cacec7e81cc15533f2b5dc505f0defc212d270c15"
 dependencies = [
  "heck 0.5.0",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "openapiv3",
  "proc-macro2",
  "quote",
@@ -3922,6 +5159,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -4160,7 +5403,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -4179,6 +5422,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4188,6 +5450,20 @@ dependencies = [
  "bitflags 2.10.0",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "ron"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
+dependencies = [
+ "bitflags 2.10.0",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "typeid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -4215,6 +5491,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
+ "serde",
  "sha2 0.10.9",
  "signature",
  "spki",
@@ -4382,6 +5659,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4527,6 +5813,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-hex"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca37e3e4d1b39afd7ff11ee4e947efae85adfddf4841787bfa47c470e96dc26d"
+dependencies = [
+ "array-init",
+ "serde",
+ "smallvec 0.6.14",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4592,6 +5889,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4602,9 +5908,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4644,7 +5950,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.8.22",
  "schemars 0.9.0",
  "schemars 1.0.4",
@@ -4672,7 +5978,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -4689,9 +5995,26 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libudev",
- "mach2",
+ "mach2 0.4.2",
  "nix 0.24.3",
  "regex",
+ "winapi",
+]
+
+[[package]]
+name = "serialport"
+version = "4.7.1-alpha.0"
+source = "git+https://github.com/oxidecomputer/serialport-rs?branch=illumos-support-4.7.1#8d0fd3a8a226b9160dc6c11f15235e5455bcbdb5"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "io-kit-sys 0.4.1",
+ "mach2 0.4.2",
+ "nix 0.26.4",
+ "scopeguard",
+ "unescaper",
  "winapi",
 ]
 
@@ -4704,6 +6027,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.12",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4784,6 +6118,12 @@ checksum = "5584bfb3e0d348139d8210285e39f6d2f8a1902ac06de343e06357d1d763d8e6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -5038,6 +6378,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
+]
+
+[[package]]
+name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
@@ -5061,7 +6410,7 @@ dependencies = [
  "byteorder",
  "cfg-if",
  "defmt 0.3.100",
- "heapless",
+ "heapless 0.8.0",
  "managed",
 ]
 
@@ -5080,6 +6429,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -5157,6 +6509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5174,6 +6535,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5263,7 +6636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -5291,6 +6664,12 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -5433,6 +6812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -5502,6 +6882,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tlvc"
+version = "0.4.1"
+source = "git+https://github.com/oxidecomputer/tlvc#7a96eab94c8aec9120412d8601ffd68853957da3"
+dependencies = [
+ "crc",
+ "thiserror 2.0.18",
+ "zerocopy",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "tlvc-text"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/tlvc#7a96eab94c8aec9120412d8601ffd68853957da3"
+dependencies = [
+ "ron 0.8.1",
+ "serde",
+ "tlvc",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5606,13 +7008,28 @@ version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5634,12 +7051,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -5650,7 +7076,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -5664,7 +7090,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow 0.7.14",
@@ -5672,11 +7098,11 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 0.7.14",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5687,9 +7113,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -5834,11 +7260,35 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.6",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.58",
  "url",
  "utf-8",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -5900,10 +7350,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uf2-decode"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca77d41ab27e3fa45df42043f96c79b80c6d8632eed906b54681d8d47ab00623"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unescaper"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7285e83a80ce76f5e7bce79fa41f68d78ba62d1003cf27bf748ab24413808cf4"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -5930,6 +7395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5952,6 +7423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5961,6 +7438,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6067,6 +7545,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "attest-data",
+ "cfg-if",
  "clap",
  "dice-mfg-msgs",
  "dice-verifier",
@@ -6093,6 +7572,18 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vsss-rs"
@@ -6505,6 +7996,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6515,6 +8012,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x509-cert"
@@ -6556,17 +8062,17 @@ name = "yubihsm"
 version = "0.42.0"
 source = "git+https://github.com/oxidecomputer/yubihsm.rs?branch=v0.42.0-with-audit#ab1d0ac182ae949567d988ddb2fc168ea45e4556"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "bitflags 2.10.0",
  "cbc",
  "cmac",
  "ecdsa",
  "ed25519",
- "hmac",
+ "hmac 0.12.1",
  "log",
  "p256",
  "p384",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "rand_core 0.6.4",
  "rusb",
  "serde",
@@ -6589,7 +8095,7 @@ dependencies = [
  "env_logger",
  "hex",
  "log",
- "ron",
+ "ron 0.8.1",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -6691,6 +8197,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "aes 0.9.1",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.4.3",
+ "hmac 0.13.0",
+ "indexmap 2.14.0",
+ "lzma-rust2",
+ "memchr",
+ "pbkdf2 0.13.0",
+ "ppmd-rust",
+ "sha1 0.11.0",
+ "time",
+ "typed-path",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+
+[[package]]
 name = "zmij"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6719,4 +8258,44 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7545,7 +7545,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "attest-data",
- "cfg-if",
  "clap",
  "dice-mfg-msgs",
  "dice-verifier",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = { version = "1.0.103", default-features = false }
 async-trait = "0.1.89"
 attest.path = "attest"
 camino = { version = "1.2.4", default-features = false }
+cfg-if = { version = "1", default-features = false }
 chrono = { version = "0.4.45", default-features=false }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 clap-verbosity = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = { version = "1.0.103", default-features = false }
 async-trait = "0.1.89"
 attest.path = "attest"
 camino = { version = "1.2.4", default-features = false }
-cfg-if = { version = "1", default-features = false }
 chrono = { version = "0.4.45", default-features=false }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 clap-verbosity = "2.1.0"

--- a/attest-time/Cargo.toml
+++ b/attest-time/Cargo.toml
@@ -13,6 +13,13 @@ dice-verifier = { path = "../verifier" }
 env_logger.workspace = true
 log.workspace = true
 tokio = { workspace = true, features = ["full"] }
+slog.workspace = true
+slog-async.workspace = true
+slog-envlogger.workspace = true
+slog-stdlog.workspace = true
+slog-term.workspace = true
 
 [features]
+default = ["hiffy"]
 ipcc = ["dice-verifier/ipcc"]
+hiffy = []

--- a/attest-time/src/main.rs
+++ b/attest-time/src/main.rs
@@ -4,12 +4,11 @@
 
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
+#[cfg(feature = "hiffy")]
+use dice_verifier::hiffy::{AttestHiffy, AttestTask};
 #[cfg(feature = "ipcc")]
 use dice_verifier::ipcc::AttestIpcc;
-use dice_verifier::{
-    Attest, Nonce,
-    hiffy::{AttestHiffy, AttestTask},
-};
+use dice_verifier::{Attest, Nonce};
 use std::{
     fmt,
     io::{self, Write},
@@ -95,7 +94,29 @@ async fn main() -> Result<()> {
     let attest: Box<dyn Attest> = match args.interface {
         #[cfg(feature = "ipcc")]
         Interface::Ipcc => Box::new(AttestIpcc::new()),
-        Interface::Hiffy => Box::new(AttestHiffy::new(AttestTask::Rot)),
+        Interface::Hiffy => {
+            #[cfg(feature = "hiffy")]
+            {
+                use slog::Drain;
+
+                let stderr_decorator = slog_term::TermDecorator::new().build();
+                let stderr_drain =
+                    slog_term::FullFormat::new(stderr_decorator).build().fuse();
+                let drain = slog_envlogger::LogBuilder::new(stderr_drain)
+                    .parse("RUST_LOG")
+                    .filter(None, slog::FilterLevel::Warning)
+                    .build()
+                    .fuse();
+                let drain = slog_async::Async::new(drain).build().fuse();
+                let logger = slog::Logger::root(drain, slog::o!());
+
+                Box::new(AttestHiffy::new(AttestTask::Rot, &logger))
+            }
+            #[cfg(not(feature = "hiffy"))]
+            {
+                panic!("hiffy feature not built in; choose another interface")
+            }
+        }
     };
 
     // we do not care about the nonce, all 0's will require the same amount of

--- a/verifier-cli/Cargo.toml
+++ b/verifier-cli/Cargo.toml
@@ -8,7 +8,6 @@ license = "MPL-2.0"
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 attest-data = { path = "../attest-data", features = ["std"] }
-cfg-if.workspace = true
 clap.workspace = true
 dice-mfg-msgs = { path = "../dice-mfg-msgs", features = ["std"] }
 ed25519-dalek = { workspace = true, features = ["std"] }

--- a/verifier-cli/Cargo.toml
+++ b/verifier-cli/Cargo.toml
@@ -8,6 +8,7 @@ license = "MPL-2.0"
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 attest-data = { path = "../attest-data", features = ["std"] }
+cfg-if.workspace = true
 clap.workspace = true
 dice-mfg-msgs = { path = "../dice-mfg-msgs", features = ["std"] }
 ed25519-dalek = { workspace = true, features = ["std"] }
@@ -23,11 +24,13 @@ slog-envlogger.workspace = true
 slog-stdlog.workspace = true
 slog-term.workspace = true
 tempfile.workspace = true
-dice-verifier.path = "../verifier"
+dice-verifier = { path = "../verifier", default-features = false }
 x509-cert = { workspace = true, default-features = true }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
 [features]
+default = ["hiffy"]
+hiffy = ["dice-verifier/hiffy"]
 ipcc = ["dice-verifier/ipcc"]
 sled-agent = ["dice-verifier/sled-agent"]

--- a/verifier-cli/src/main.rs
+++ b/verifier-cli/src/main.rs
@@ -264,7 +264,7 @@ async fn main() -> Result<()> {
             }
         }
     };
-    let mut attest = get_attest(interface, &logger)?;
+    let attest = get_attest(interface, &logger)?;
 
     match args.command {
         AttestCommand::Attest { nonce } => {
@@ -344,7 +344,7 @@ async fn main() -> Result<()> {
             let platform_id = match work_dir {
                 Some(w) => {
                     verify(
-                        attest.as_mut(),
+                        attest.as_ref(),
                         ca_cert.as_deref(),
                         corpus.as_deref(),
                         self_signed,
@@ -358,7 +358,7 @@ async fn main() -> Result<()> {
                     }
                     let work_dir = tempfile::tempdir()?;
                     verify(
-                        attest.as_mut(),
+                        attest.as_ref(),
                         ca_cert.as_deref(),
                         corpus.as_deref(),
                         self_signed,
@@ -393,7 +393,7 @@ async fn main() -> Result<()> {
             verify_measurements(&cert_chain, &log, &corpus)?;
         }
         AttestCommand::MeasurementSet => {
-            let set = measurement_set(attest.as_mut()).await?;
+            let set = measurement_set(attest.as_ref()).await?;
             for item in set.into_iter() {
                 println!("* {item}");
             }
@@ -403,7 +403,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn measurement_set(attest: &mut dyn Attest) -> Result<MeasurementSet> {
+async fn measurement_set(attest: &dyn Attest) -> Result<MeasurementSet> {
     info!("getting measurement log");
     let log = attest
         .get_measurement_log()
@@ -469,7 +469,7 @@ fn verify_measurements(
 }
 
 async fn verify(
-    attest: &mut dyn Attest,
+    attest: &dyn Attest,
     ca_cert: Option<&Path>,
     corpus: Option<&Path>,
     self_signed: bool,

--- a/verifier-cli/src/main.rs
+++ b/verifier-cli/src/main.rs
@@ -6,14 +6,13 @@ use anyhow::{anyhow, Context, Result};
 use attest_data::{Attestation, Log, Nonce, Nonce32};
 use clap::{Parser, Subcommand, ValueEnum};
 use dice_mfg_msgs::PlatformId;
+#[cfg(feature = "hiffy")]
+use dice_verifier::hiffy::{AttestHiffy, AttestTask};
 #[cfg(feature = "ipcc")]
 use dice_verifier::ipcc::AttestIpcc;
 #[cfg(feature = "sled-agent")]
 use dice_verifier::sled_agent::AttestSledAgent;
-use dice_verifier::{
-    hiffy::{AttestHiffy, AttestTask},
-    Attest, MeasurementSet, ReferenceMeasurements,
-};
+use dice_verifier::{Attest, MeasurementSet, ReferenceMeasurements};
 use log::{info, warn};
 use pem_rfc7468::LineEnding;
 use rats_corim::Corim;
@@ -34,12 +33,16 @@ fn get_attest(interface: Interface, log: &Logger) -> Result<Box<dyn Attest>> {
     match interface {
         #[cfg(feature = "ipcc")]
         Interface::Ipcc => Ok(Box::new(AttestIpcc::new())),
-        Interface::Rot => Ok(Box::new(AttestHiffy::new(AttestTask::Rot))),
+        #[cfg(feature = "hiffy")]
+        Interface::Rot => Ok(Box::new(AttestHiffy::new(AttestTask::Rot, log))),
         #[cfg(feature = "sled-agent")]
         Interface::SledAgent(addr) => {
             Ok(Box::new(AttestSledAgent::new(addr, log)))
         }
-        Interface::Sprot => Ok(Box::new(AttestHiffy::new(AttestTask::Sprot))),
+        #[cfg(feature = "hiffy")]
+        Interface::Sprot => {
+            Ok(Box::new(AttestHiffy::new(AttestTask::Sprot, log)))
+        }
     }
 }
 
@@ -172,9 +175,11 @@ enum AttestCommand {
 pub enum Interface {
     #[cfg(feature = "ipcc")]
     Ipcc,
+    #[cfg(feature = "hiffy")]
     Rot,
     #[cfg(feature = "sled-agent")]
     SledAgent(std::net::SocketAddrV6),
+    #[cfg(feature = "hiffy")]
     Sprot,
 }
 
@@ -230,14 +235,36 @@ async fn main() -> Result<()> {
     let interface = match args.interface {
         #[cfg(feature = "ipcc")]
         InterfaceArg::Ipcc => Interface::Ipcc,
-        InterfaceArg::Rot => Interface::Rot,
         #[cfg(feature = "sled-agent")]
         InterfaceArg::SledAgent => {
             Interface::SledAgent(args.sled_addr.unwrap())
         }
-        InterfaceArg::Sprot => Interface::Sprot,
+        InterfaceArg::Rot => {
+            #[cfg(feature = "hiffy")]
+            {
+                Interface::Rot
+            }
+            #[cfg(not(feature = "hiffy"))]
+            {
+                panic!(
+                    "hiffy support not built in; choose a different interface"
+                )
+            }
+        }
+        InterfaceArg::Sprot => {
+            #[cfg(feature = "hiffy")]
+            {
+                Interface::Sprot
+            }
+            #[cfg(not(feature = "hiffy"))]
+            {
+                panic!(
+                    "hiffy support not built in; choose a different interface"
+                )
+            }
+        }
     };
-    let attest = get_attest(interface, &logger)?;
+    let mut attest = get_attest(interface, &logger)?;
 
     match args.command {
         AttestCommand::Attest { nonce } => {
@@ -317,7 +344,7 @@ async fn main() -> Result<()> {
             let platform_id = match work_dir {
                 Some(w) => {
                     verify(
-                        attest.as_ref(),
+                        attest.as_mut(),
                         ca_cert.as_deref(),
                         corpus.as_deref(),
                         self_signed,
@@ -331,7 +358,7 @@ async fn main() -> Result<()> {
                     }
                     let work_dir = tempfile::tempdir()?;
                     verify(
-                        attest.as_ref(),
+                        attest.as_mut(),
                         ca_cert.as_deref(),
                         corpus.as_deref(),
                         self_signed,
@@ -366,7 +393,7 @@ async fn main() -> Result<()> {
             verify_measurements(&cert_chain, &log, &corpus)?;
         }
         AttestCommand::MeasurementSet => {
-            let set = measurement_set(attest.as_ref()).await?;
+            let set = measurement_set(attest.as_mut()).await?;
             for item in set.into_iter() {
                 println!("* {item}");
             }
@@ -376,7 +403,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn measurement_set(attest: &dyn Attest) -> Result<MeasurementSet> {
+async fn measurement_set(attest: &mut dyn Attest) -> Result<MeasurementSet> {
     info!("getting measurement log");
     let log = attest
         .get_measurement_log()
@@ -442,7 +469,7 @@ fn verify_measurements(
 }
 
 async fn verify(
-    attest: &dyn Attest,
+    attest: &mut dyn Attest,
     ca_cert: Option<&Path>,
     corpus: Option<&Path>,
     self_signed: bool,

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -25,6 +25,12 @@ tokio = { workspace = true, features = [ "net", "rt", "time", "process" ] }
 tempfile.workspace = true
 thiserror.workspace = true
 x509-cert = { workspace = true, default-features = true }
+humility-probes-core = { git =  "https://github.com/oxidecomputer/humility", rev = "80dae8d2af4d9ba34e583f17913780fe449aa9f0", optional = true }
+humility-core = { git =  "https://github.com/oxidecomputer/humility" , rev = "80dae8d2af4d9ba34e583f17913780fe449aa9f0", optional = true }
+humility-idol = { git =  "https://github.com/oxidecomputer/humility", rev = "80dae8d2af4d9ba34e583f17913780fe449aa9f0", optional = true  }
+humility-hiffy = { git =  "https://github.com/oxidecomputer/humility" , rev = "80dae8d2af4d9ba34e583f17913780fe449aa9f0", optional = true }
+# This is only for handling some of the errors from humility
+anyhow.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true
@@ -35,7 +41,9 @@ pki-playground.workspace = true
 attest-data = { path = "../attest-data", features = ["std", "testing"] }
 
 [features]
+default = ["hiffy"]
 testing = []
 ipcc = ["libipcc"]
 mock = ["ed25519-dalek/pem"]
 sled-agent = ["sled-agent-client", "sled-agent-types-versions"]
+hiffy = ["humility-hiffy", "humility-idol", "humility-core", "humility-probes-core"]

--- a/verifier/src/hiffy.rs
+++ b/verifier/src/hiffy.rs
@@ -4,41 +4,15 @@
 
 use attest_data::{Attestation, Log, Nonce, Nonce32};
 use hubpack::SerializedSize;
-use sha3::{Digest, Sha3_256};
-use std::{
-    fmt,
-    io::{Read, Write},
-    path::Path,
-    process::Output,
-};
-use tempfile::NamedTempFile;
 use thiserror::Error;
-use tokio::process::Command;
 use x509_cert::{der::Decode, Certificate, PkiPath};
 
 use crate::{Attest, AttestError};
-
-/// This trait implements the hubris attestation API exposed by the `attest`
-/// task in the RoT and proxied through the `sprot` task in the SP.
-#[async_trait::async_trait]
-pub trait AttestSprot {
-    async fn attest_len(&self) -> Result<u32, AttestHiffyError>;
-    async fn attest(
-        &self,
-        nonce: &Nonce32,
-        out: &mut [u8],
-    ) -> Result<(), AttestHiffyError>;
-    async fn cert_chain_len(&self) -> Result<u32, AttestHiffyError>;
-    async fn cert_len(&self, index: u32) -> Result<u32, AttestHiffyError>;
-    async fn cert(
-        &self,
-        index: u32,
-        out: &mut [u8],
-    ) -> Result<(), AttestHiffyError>;
-    async fn log(&self, out: &mut [u8]) -> Result<(), AttestHiffyError>;
-    async fn log_len(&self) -> Result<u32, AttestHiffyError>;
-    async fn record(&self, data: &[u8]) -> Result<(), AttestHiffyError>;
-}
+use humility_core::hubris::HubrisArchive;
+use humility_hiffy::HiffyContext;
+use humility_idol::{HubrisIdol, IdolArgument};
+use humility_probes_core::{HubrisAttach, ProbeCore};
+use slog::Logger;
 
 /// The `AttestHiffy` type can speak to the `Attest` tasks via either the RoT
 /// directly or through SpRot task in the SP. This enum is used to control
@@ -49,15 +23,13 @@ pub enum AttestTask {
     Sprot,
 }
 
-/// We use the `Display` trait to produce the string representation of the
-/// attest task name. In the RoT the task is called `Attest`, in the SP the
-/// Attest API is exposed by the task named `SpRot`.
-impl fmt::Display for AttestTask {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Rot => write!(f, "Attest"),
-            Self::Sprot => write!(f, "SpRot"),
-        }
+impl AttestTask {
+    fn get_command(&self, cmd: &str) -> String {
+        let task = match self {
+            AttestTask::Rot => "Attest",
+            AttestTask::Sprot => "SpRot",
+        };
+        format!("{task}.{cmd}")
     }
 }
 
@@ -65,266 +37,108 @@ impl fmt::Display for AttestTask {
 /// `humility hiffy` interface.
 #[derive(Debug, Error)]
 pub enum AttestHiffyError {
-    #[error("Failed to parse u32 from hiffy hex output: {0}")]
-    BadU32(#[from] std::num::ParseIntError),
-    #[error("Hiffy command failed: {0}")]
-    ExitStatus(std::process::ExitStatus),
-    #[error("Failed to hubpack something: {0}")]
-    Serialize(#[from] hubpack::Error),
-    #[error("Failed to do something w/ a tempfile: {0}")]
-    TempFile(#[from] std::io::Error),
-    // Failure to run `humility` yields a `std::io::Error` from
-    // `std::process::Command`, but it is distinctly *not* related to a tempfile
-    // in any way. Give this failure mode a more distinctive form.
-    #[error("Failed to run humility: {0}")]
-    Humility(std::io::Error),
+    /// Failure from idol
+    #[error("idol error")]
+    Idol(#[source] anyhow::Error),
+    /// Failure from hiffy context
+    #[error("hiffy context error")]
+    HiffyContext(#[source] anyhow::Error),
+    /// Failure from hiffy
+    #[error("hiffy error")]
+    Hiffy(#[source] humility_hiffy::HiffyError),
+    /// Error calling idol function
+    #[error("idol call error")]
+    IdolCall(#[source] humility_hiffy::HiffyError),
+    #[error("HUMILITY_ARCHIVE unset")]
+    HumilityArchiveUnset(#[source] std::env::VarError),
+    #[error("HUMILTIY_PROBE unset")]
+    HumilityProbeUnset(#[source] std::env::VarError),
+    #[error("Hubris archive load failed")]
+    HubrisArchive(#[source] anyhow::Error),
+    #[error("probe attach failed")]
+    ProbeAttach(#[source] anyhow::Error),
 }
 
 /// A type to simplify the execution of the HIF operations exposed by the RoT
-/// Attest task.
+/// Attest task. We intentionally do not attach the probe to avoid the
+/// need to have &mut everywhere on functions
 pub struct AttestHiffy {
-    task: AttestTask,
+    log: Logger,
+    target: AttestTask,
+    //probe: String,
 }
 
 impl AttestHiffy {
-    const CHUNK_SIZE: usize = 256;
+    pub fn new(target: AttestTask, log: &Logger) -> Self {
+        let log = log.new(slog::o!());
 
-    pub fn new(task: AttestTask) -> Self {
-        AttestHiffy { task }
+        Self { log, target }
     }
 
-    /// `humility` returns u32s as hex strings prefixed with "0x". This
-    /// function expects a string formatted like an output string from hiffy
-    /// returning a u32. If the string is not prefixed with "0x" it is assumed
-    /// to be decimal. Currently this function ignores the interface and
-    /// operation names from the string. Future work may check that these are
-    /// consistent with the operation executed.
-    fn u32_from_cmd_output(output: Output) -> Result<u32, AttestHiffyError> {
-        if output.status.success() {
-            // check interface & operation name?
-            let output = String::from_utf8_lossy(&output.stdout);
-            let output: Vec<&str> = output.trim().split(' ').collect();
-            let output = output[output.len() - 1];
-
-            let (output, _) = match output.strip_prefix("0x") {
-                Some(s) => (s, 16),
-                None => (output, 10),
-            };
-
-            Ok(u32::from_str_radix(output, 16)
-                .map_err(AttestHiffyError::BadU32)?)
-        } else {
-            Err(AttestHiffyError::ExitStatus(output.status))
-        }
-    }
-
-    /// This convenience function encapsulates a pattern common to
-    /// the hiffy command line for the `Attest` operations that get the
-    /// lengths of the data returned in leases.
-    async fn get_len_cmd(
+    pub fn new_hiffy(
         &self,
-        op: &str,
-        args: Option<String>,
-    ) -> Result<u32, AttestHiffyError> {
-        // rely on environment for target & archive?
-        // check that they are set before continuing
-        let mut cmd = Command::new("humility");
+    ) -> Result<(ProbeCore, HubrisArchive), AttestHiffyError> {
+        // This matches the behavior of the old humility binary behavior.
+        // Passing in the paths directly requires some clap/CLI rework.
+        // We also can't currently do this at creation time due to
+        // some underlying issues with humility + async
+        let hubris = std::env::var("HUMILITY_ARCHIVE")
+            .map_err(AttestHiffyError::HumilityArchiveUnset)?;
+        let probe = std::env::var("HUMILITY_PROBE")
+            .map_err(AttestHiffyError::HumilityProbeUnset)?;
 
-        cmd.arg("hiffy");
-        cmd.arg("--call");
-        cmd.arg(format!("{}.{}", self.task, op));
-        if let Some(a) = args {
-            cmd.arg(format!("--arguments={a}"));
-        }
+        let hubris = HubrisArchive::load_from_path(&hubris, &self.log)
+            .map_err(AttestHiffyError::HubrisArchive)?;
 
-        let output = cmd.output().await.map_err(AttestHiffyError::Humility)?;
-        Self::u32_from_cmd_output(output)
-    }
+        let core = hubris.attach_probe(&probe, 8000, &self.log).unwrap();
 
-    /// This convenience function encapsulates a pattern common to the hiffy
-    /// command line for the `Attest` operations that return blobs in chunks.
-    async fn get_chunk(
-        &self,
-        op: &str,
-        length: usize,
-        output: &Path,
-        args: Option<&str>,
-        input: Option<&str>,
-    ) -> Result<(), AttestHiffyError> {
-        let mut cmd = Command::new("humility");
-
-        cmd.arg("hiffy");
-        cmd.arg(format!("--call={}.{}", self.task, op));
-        cmd.arg(format!("--num={length}"));
-        cmd.arg(format!("--output={}", output.to_string_lossy()));
-        if let Some(args) = args {
-            cmd.arg("--arguments");
-            cmd.arg(args);
-        }
-        if let Some(i) = input {
-            cmd.arg(format!("--input={i}"));
-        }
-
-        let output = cmd.output().await?;
-        if output.status.success() {
-            Ok(())
-        } else {
-            Err(AttestHiffyError::ExitStatus(output.status))
-        }
+        Ok((core, hubris))
     }
 }
 
-#[async_trait::async_trait]
-impl AttestSprot for AttestHiffy {
-    async fn attest(
-        &self,
-        nonce: &Nonce32,
-        out: &mut [u8],
-    ) -> Result<(), AttestHiffyError> {
-        let mut attestation_tmp = tempfile::NamedTempFile::new()?;
-        let mut nonce_tmp = tempfile::NamedTempFile::new()?;
-
-        let mut buf = [0u8; Nonce32::MAX_SIZE];
-        hubpack::serialize(&mut buf, &nonce)
-            .map_err(AttestHiffyError::Serialize)?;
-        nonce_tmp.write_all(&buf)?;
-
-        self.get_chunk(
-            "attest",
-            out.len(),
-            attestation_tmp.path(),
-            None,
-            Some(&nonce_tmp.path().to_string_lossy()),
-        )
-        .await?;
-        Ok(attestation_tmp.read_exact(&mut out[..])?)
-    }
-
-    /// Get length of the measurement log in bytes.
-    async fn attest_len(&self) -> Result<u32, AttestHiffyError> {
-        self.get_len_cmd("attest_len", None).await
-    }
-
-    /// Get length of the certificate chain from the Attest task. This cert
-    /// chain may be self signed or will terminate at the intermediate before
-    /// the root.
-    async fn cert_chain_len(&self) -> Result<u32, AttestHiffyError> {
-        self.get_len_cmd("cert_chain_len", None).await
-    }
-
-    /// Get length of the certificate at the provided index in bytes.
-    async fn cert_len(&self, index: u32) -> Result<u32, AttestHiffyError> {
-        self.get_len_cmd("cert_len", Some(format!("index={index}")))
-            .await
-    }
-
-    async fn cert(
-        &self,
-        index: u32,
-        out: &mut [u8],
-    ) -> Result<(), AttestHiffyError> {
-        for offset in
-            (0..out.len() - Self::CHUNK_SIZE).step_by(Self::CHUNK_SIZE)
-        {
-            let mut tmp = tempfile::NamedTempFile::new()?;
-            self.get_chunk(
-                "cert",
-                Self::CHUNK_SIZE,
-                tmp.path(),
-                Some(&format!("index={index},offset={offset}")),
-                None,
-            )
-            .await?;
-            tmp.read_exact(&mut out[offset..offset + Self::CHUNK_SIZE])?;
-        }
-
-        let remain = out.len() % Self::CHUNK_SIZE;
-        if remain != 0 {
-            let offset = out.len() - remain;
-            let mut tmp = tempfile::NamedTempFile::new()?;
-            self.get_chunk(
-                "cert",
-                remain,
-                tmp.path(),
-                Some(&format!("index={index},offset={offset}")),
-                None,
-            )
-            .await?;
-            tmp.read_exact(&mut out[offset..])?;
-        }
-
-        Ok(())
-    }
-
-    /// Get measurement log. This function assumes that the slice provided
-    /// is sufficiently large to hold the log.
-    async fn log(&self, out: &mut [u8]) -> Result<(), AttestHiffyError> {
-        for offset in
-            (0..out.len() - Self::CHUNK_SIZE).step_by(Self::CHUNK_SIZE)
-        {
-            let mut tmp = tempfile::NamedTempFile::new()?;
-            self.get_chunk(
-                "log",
-                Self::CHUNK_SIZE,
-                tmp.path(),
-                Some(&format!("offset={offset}")),
-                None,
-            )
-            .await?;
-            tmp.read_exact(&mut out[offset..offset + Self::CHUNK_SIZE])?;
-        }
-
-        let remain = out.len() % Self::CHUNK_SIZE;
-        if remain != 0 {
-            let offset = out.len() - remain;
-            let mut tmp = tempfile::NamedTempFile::new()?;
-            self.get_chunk(
-                "log",
-                remain,
-                tmp.path(),
-                Some(&format!("offset={offset}")),
-                None,
-            )
-            .await?;
-            tmp.read_exact(&mut out[offset..])?;
-        }
-
-        Ok(())
-    }
-
-    /// Get length of the measurement log in bytes.
-    async fn log_len(&self) -> Result<u32, AttestHiffyError> {
-        self.get_len_cmd("log_len", None).await
-    }
-
-    /// Record the sha3 hash of a file.
-    async fn record(&self, data: &[u8]) -> Result<(), AttestHiffyError> {
-        let digest = Sha3_256::digest(data);
-        let mut tmp = NamedTempFile::new()?;
-        tmp.write_all(digest.as_slice())?;
-
-        let mut cmd = Command::new("humility");
-
-        cmd.arg("hiffy");
-        cmd.arg(format!("--call={}.record", self.task));
-        cmd.arg(format!("--input={}", tmp.path().to_string_lossy()));
-        cmd.arg("--arguments=algorithm=Sha3_256");
-
-        let output = cmd.output().await?;
-        if output.status.success() {
-            Ok(())
-        } else {
-            Err(AttestHiffyError::ExitStatus(output.status))
-        }
-    }
-}
+const TRANSFER_SIZE: usize = 128;
 
 #[async_trait::async_trait]
 impl Attest for AttestHiffy {
     async fn get_measurement_log(&self) -> Result<Log, AttestError> {
-        let log_len = self.log_len().await?;
-        let mut log = vec![0u8; log_len as usize];
-        self.log(&mut log).await?;
+        let (mut core, hubris) = self.new_hiffy()?;
+
+        let mut context = HiffyContext::new(
+            &hubris,
+            &mut core,
+            std::time::Duration::from_secs(5),
+            &self.log,
+        )
+        .map_err(AttestHiffyError::HiffyContext)?;
+
+        let log_len_op = hubris
+            .get_idol_command(self.target.get_command("log_len").as_str())
+            .map_err(AttestHiffyError::Idol)?;
+
+        let log_op = hubris
+            .get_idol_command(self.target.get_command("log").as_str())
+            .map_err(AttestHiffyError::Idol)?;
+
+        let log_len = context
+            .call::<u32>(&mut core, &log_len_op, &[], None, None)
+            .map_err(AttestHiffyError::Hiffy)? as usize;
+
+        let mut log = vec![0u8; log_len];
+        let mut offset = 0;
+
+        for chunk in log.chunks_mut(TRANSFER_SIZE) {
+            context
+                .call::<()>(
+                    &mut core,
+                    &log_op,
+                    &[("offset", IdolArgument::Scalar(offset as u64))],
+                    None,
+                    Some(chunk),
+                )
+                .map_err(AttestHiffyError::IdolCall)?;
+            offset += chunk.len();
+        }
+
         let (log, _): (Log, _) =
             hubpack::deserialize(&log).map_err(AttestError::Deserialize)?;
 
@@ -333,13 +147,65 @@ impl Attest for AttestHiffy {
 
     async fn get_certificates(&self) -> Result<PkiPath, AttestError> {
         let mut cert_chain = PkiPath::new();
-        for index in 0..self.cert_chain_len().await? {
-            let cert_len = self.cert_len(index).await?;
+
+        let (mut core, hubris) = self.new_hiffy()?;
+
+        let mut context = HiffyContext::new(
+            &hubris,
+            &mut core,
+            std::time::Duration::from_secs(5),
+            &self.log,
+        )
+        .map_err(AttestHiffyError::HiffyContext)?;
+
+        let cert_chain_len_op = hubris
+            .get_idol_command(
+                self.target.get_command("cert_chain_len").as_str(),
+            )
+            .map_err(AttestHiffyError::Idol)?;
+
+        let cert_len_op = hubris
+            .get_idol_command(self.target.get_command("cert_len").as_str())
+            .map_err(AttestHiffyError::Idol)?;
+
+        let cert_op = hubris
+            .get_idol_command(self.target.get_command("cert").as_str())
+            .map_err(AttestHiffyError::Idol)?;
+
+        let cert_count = context
+            .call::<u32>(&mut core, &cert_chain_len_op, &[], None, None)
+            .map_err(AttestHiffyError::Hiffy)?
+            as usize;
+
+        for cert_index in 0..cert_count {
+            let cert_len = context
+                .call::<u32>(
+                    &mut core,
+                    &cert_len_op,
+                    &[("index", IdolArgument::Scalar(cert_index as u64))],
+                    None,
+                    None,
+                )
+                .map_err(AttestHiffyError::IdolCall)?;
+            let mut offset = 0;
             let mut cert = vec![0u8; cert_len as usize];
-            self.cert(index, &mut cert).await?;
+            for chunk in cert.chunks_mut(TRANSFER_SIZE) {
+                context
+                    .call::<()>(
+                        &mut core,
+                        &cert_op,
+                        &[
+                            ("index", IdolArgument::Scalar(cert_index as u64)),
+                            ("offset", IdolArgument::Scalar(offset as u64)),
+                        ],
+                        None,
+                        Some(chunk),
+                    )
+                    .map_err(AttestHiffyError::IdolCall)?;
+                offset += chunk.len();
+            }
 
             let cert = Certificate::from_der(&cert)?;
-
             cert_chain.push(cert);
         }
 
@@ -348,12 +214,47 @@ impl Attest for AttestHiffy {
 
     async fn attest(&self, nonce: &Nonce) -> Result<Attestation, AttestError> {
         let nonce: &Nonce32 = nonce.try_into()?;
-        let attest_len = self.attest_len().await?;
-        let mut out = vec![0u8; attest_len as usize];
-        AttestSprot::attest(self, nonce, &mut out).await?;
+
+        let (mut core, hubris) = self.new_hiffy()?;
+
+        let mut buf = [0u8; Nonce32::MAX_SIZE];
+        hubpack::serialize(&mut buf, &nonce).map_err(AttestError::Serialize)?;
+
+        let mut context = HiffyContext::new(
+            &hubris,
+            &mut core,
+            std::time::Duration::from_secs(5),
+            &self.log,
+        )
+        .map_err(AttestHiffyError::HiffyContext)?;
+
+        let attest_len_op = hubris
+            .get_idol_command(self.target.get_command("attest_len").as_str())
+            .map_err(AttestHiffyError::Idol)?;
+
+        let attest_op = hubris
+            .get_idol_command(self.target.get_command("attest").as_str())
+            .map_err(AttestHiffyError::Idol)?;
+
+        let attest_len = context
+            .call::<u32>(&mut core, &attest_len_op, &[], None, None)
+            .map_err(AttestHiffyError::Hiffy)?
+            as usize;
+
+        let mut attest = vec![0u8; attest_len];
+
+        context
+            .call::<()>(
+                &mut core,
+                &attest_op,
+                &[],
+                Some(&buf),
+                Some(&mut attest),
+            )
+            .map_err(AttestHiffyError::IdolCall)?;
 
         let (attestation, _): (Attestation, _) =
-            hubpack::deserialize(&out).map_err(AttestError::Deserialize)?;
+            hubpack::deserialize(&attest).map_err(AttestError::Deserialize)?;
 
         Ok(attestation)
     }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -17,7 +17,9 @@ use x509_cert::{
     Certificate, PkiPath,
 };
 
+#[cfg(feature = "hiffy")]
 pub mod hiffy;
+#[cfg(feature = "hiffy")]
 use hiffy::AttestHiffyError;
 
 #[cfg(feature = "ipcc")]
@@ -41,6 +43,7 @@ pub enum AttestError {
     Certificate(#[from] der::Error),
     #[error(transparent)]
     Deserialize(hubpack::Error),
+    #[cfg(feature = "hiffy")]
     #[error(transparent)]
     Hiffy(#[from] AttestHiffyError),
     #[error("failed to send ipcc message to RoT: {0}")]


### PR DESCRIPTION
I played around with making this a library in humility and ran into a version dependency nightmare when I tried to use `attest_data` in the library. I then had the humility library just do the raw bytes but at that point I wondered why I was wrapping anything in humility in the first place.

This is the first time I'm really trying to use hiffy/idol outside the core humility binary so it's very much an experiment in what actually works