### PR TITLE
Switch to a stable toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@1.97.1
       - run: sudo apt-get update
       - run: sudo apt-get install -y pkg-config libudev-dev
       - run: cargo build --workspace
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@1.97.1
       - run: sudo apt-get update
       - run: sudo apt-get install -y pkg-config libudev-dev
       - run: cargo test --package attest-data
@@ -32,7 +32,7 @@ jobs:
       RUSTDOCFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@1.97.1
       - run: sudo apt-get update
       - run: sudo apt-get install -y pkg-config libudev-dev
       - run: cargo doc --all-features --locked --no-deps

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,5 @@
 [toolchain]
-channel = "nightly"
+# We choose a specific toolchain (rather than "stable") for repeatability.  The
+# intent is to keep this up-to-date with recently-released stable Rust.
+channel = "1.97.1"
+profile = "default"


### PR DESCRIPTION
Just using `nightly` can introduce surprises. There's no need today to use a nightly toolchain so switch to the latest stable.