### PR TITLE
Helios rot mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,6 +2459,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "helios-rot"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "camino",
+ "cfg-if",
+ "der",
+ "getrandom 0.4.3",
+ "helios-rot",
+ "p384",
+ "pki-playground",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.18",
+ "x509-cert",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4575,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "pki-playground"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/pki-playground?rev=bcd3bf2dfe36468c494eac17463a4e10be366b35#bcd3bf2dfe36468c494eac17463a4e10be366b35"
+source = "git+https://github.com/oxidecomputer/pki-playground?rev=888763c6f3d87ed3db1ccd6952d80445ea729a2d#888763c6f3d87ed3db1ccd6952d80445ea729a2d"
 dependencies = [
  "camino",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "dice-mfg",
     "dice-mfg-msgs",
     "platform-rot",
+    "helios-rot",
     "yhsm-audit",
     "verifier-cli",
 ]
@@ -38,7 +39,7 @@ libipcc = { git = "https://github.com/oxidecomputer/ipcc-rs", rev = "7cdf2ab9c8d
 log = { version = "0.4.33", features = ["std"] }
 p384 = { version = "0.13.1", default-features = false }
 pem-rfc7468 = { version = "1.0.0", default-features = false }
-pki-playground = { git = "https://github.com/oxidecomputer/pki-playground", rev = "bcd3bf2dfe36468c494eac17463a4e10be366b35" }
+pki-playground = { git = "https://github.com/oxidecomputer/pki-playground", rev = "888763c6f3d87ed3db1ccd6952d80445ea729a2d" }
 rats-corim.git = "https://github.com/oxidecomputer/rats-corim"
 ron = "0.8"
 rpassword = "7.5.4"

--- a/helios-rot/Cargo.toml
+++ b/helios-rot/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "helios-rot"
+version = "0.1.0"
+edition = "2024"
+description = "a library crate implementing an interface to the Helios RoT"
+license = "MPL-2.0"
+
+[dependencies]
+async-trait.workspace = true
+der.workspace = true
+getrandom.workspace = true
+p384 = { workspace = true, features = ["ecdsa", "ecdsa-core", "pem", "pkcs8", "std"] }
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true, features = ["macros"] }
+thiserror.workspace = true
+x509-cert = { workspace = true, default-features = true }
+
+[build-dependencies]
+anyhow.workspace = true
+camino = { workspace = true, optional = true }
+cfg-if.workspace = true
+pki-playground = { workspace = true, optional = true }
+
+[features]
+unittest = ["camino", "pki-playground"]
+
+[dev-dependencies]
+helios-rot = { path = ".", features = ["unittest"] }

--- a/helios-rot/README.md
+++ b/helios-rot/README.md
@@ -1,0 +1,3 @@
+This crate hosts the interface / trait for the RoT we're building into Helios.
+It contains both a mock implementation and an implementation built on the
+IOCTLs exposed by the Helios driver.

--- a/helios-rot/build.rs
+++ b/helios-rot/build.rs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::Result;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "unittest")] {
+        use anyhow::{anyhow, Context};
+        use camino::Utf8PathBuf;
+        use pki_playground::{config, OutputFileExistsBehavior};
+        use std::env;
+    }
+}
+
+#[cfg(feature = "unittest")]
+fn pki_setup() -> Result<()> {
+    // output directory where we put generated test inputs
+    let out = Utf8PathBuf::from(
+        env::var("OUT_DIR").context("Failed to get OUT_DIR")?,
+    );
+
+    let config_path = "test-pki.kdl";
+    let doc = config::load_and_validate(config_path.as_ref()).map_err(|e| {
+        anyhow!("Loading config from \"{}\" failed: {e:?}", config_path)
+    })?;
+
+    doc.write_key_pairs(out.clone(), OutputFileExistsBehavior::Skip)
+        .map_err(|e| anyhow!("write key pairs to {out}: {e:?}"))?;
+    doc.write_certificates(out.clone(), OutputFileExistsBehavior::Skip)
+        .map_err(|e| anyhow!("write certificates to {out}: {e:?}"))?;
+    doc.write_certificate_lists(out.clone(), OutputFileExistsBehavior::Skip)
+        .map_err(|e| anyhow!("write certificate chains to {out}: {e:?}"))?;
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    #[cfg(feature = "unittest")]
+    pki_setup()?;
+
+    Ok(())
+}

--- a/helios-rot/src/lib.rs
+++ b/helios-rot/src/lib.rs
@@ -1,0 +1,246 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use p384::{
+    ecdsa::{
+        self, Signature, SigningKey,
+        signature::{SignatureEncoding, Signer},
+    },
+    pkcs8::{self, DecodePrivateKey},
+};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+use thiserror::Error;
+use x509_cert::{Certificate, PkiPath, der};
+
+const SIGNATURE_SIZE: usize =
+    core::mem::size_of::<<Signature as SignatureEncoding>::Repr>();
+
+#[derive(Debug, Error)]
+pub enum ArrayError {
+    #[error("Slice is not 96 bytes")]
+    TryFromSliceError,
+}
+
+#[serde_as]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct Array<const N: usize>(#[serde_as(as = "[_; N]")] pub [u8; N]);
+
+impl<const N: usize> Array<N> {
+    pub const LENGTH: usize = N;
+}
+
+impl<const N: usize> AsRef<[u8]> for Array<N> {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8]> for Array<N> {
+    type Error = ArrayError;
+
+    /// Attempt to create an `Array<N>` from the slice provided.
+    fn try_from(item: &[u8]) -> Result<Self, Self::Error> {
+        let item: [u8; N] = item
+            .try_into()
+            .map_err(|_| Self::Error::TryFromSliceError)?;
+        Ok(Array::<N>(item))
+    }
+}
+
+pub type P384Signature = Array<SIGNATURE_SIZE>;
+
+/// An attestation from the Illumos Rot
+pub enum Attestation {
+    P384(P384Signature),
+}
+
+#[derive(Debug, Error)]
+pub enum NonceError {
+    #[error("Only 48 byte Nonces are supported")]
+    UnsupportedLength,
+    #[error("Failed to pull 48 bytes from getrandom")]
+    Rng(#[from] getrandom::Error),
+}
+
+pub type Nonce48 = Array<48>;
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Deserialize,
+    PartialEq,
+    // The current RoT Attest API takes the nonce bytes directly (i.e. a
+    // `Nonce48`/`Array<48>`) rather than this more generic `Nonce` type.
+    // To prevent accidentally accepting this type where it currently shouldn't
+    // be accepted, we omit these for now until hubris#2375 is fixed.
+    // Serialize, SerializedSize,
+)]
+pub enum Nonce {
+    /// A 48-byte Nonce value.
+    N48(Nonce48),
+}
+
+impl Nonce {
+    pub fn from_platform_rng(len: usize) -> Result<Self, NonceError> {
+        // We currently only support 32-byte Nonce's
+        if len != Nonce48::LENGTH {
+            return Err(NonceError::UnsupportedLength);
+        }
+        let mut nonce = Array([0u8; Nonce48::LENGTH]);
+        getrandom::fill(nonce.0.as_mut_slice()).map_err(NonceError::Rng)?;
+        Ok(Nonce::N48(nonce))
+    }
+}
+
+impl AsRef<[u8]> for Nonce {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Nonce::N48(n) => n.as_ref(),
+        }
+    }
+}
+
+/// The `IllumosRot` trait is the interface to the roT in the Illumos kernel.
+pub trait IllumosRot {
+    type Error;
+
+    fn get_certificates(&self) -> Result<PkiPath, Self::Error>;
+    fn attest(&self, nonce: &Nonce) -> Result<Attestation, Self::Error>;
+}
+
+#[derive(Debug, Error)]
+pub enum IllumosRotMockError {
+    #[error("Failed to load certificate chain")]
+    DerError(#[from] der::Error),
+    #[error("Failed to load certificate chain from {}", path.display())]
+    FileRead {
+        path: PathBuf,
+        #[source]
+        error: io::Error,
+    },
+    #[error("Failed to load p384 signing key from {}", path.display())]
+    SigningKeyDecode {
+        path: PathBuf,
+        #[source]
+        error: pkcs8::Error,
+    },
+    #[error("Signature isn't 96 bytes")]
+    SignatureSize(#[from] ArrayError),
+    #[error("Signature isn't 96 bytes")]
+    SigningError(#[from] ecdsa::Error),
+}
+
+#[derive(Debug)]
+pub struct IllumosRotMock {
+    certs: PkiPath,
+    alias_key: SigningKey,
+}
+
+impl IllumosRotMock {
+    pub fn load<P: AsRef<Path>, A: AsRef<Path>>(
+        certs: P,
+        alias: A,
+    ) -> Result<Self, IllumosRotMockError> {
+        let certs = fs::read_to_string(&certs).map_err(|error| {
+            IllumosRotMockError::FileRead {
+                path: certs.as_ref().to_path_buf(),
+                error,
+            }
+        })?;
+        let certs = Certificate::load_pem_chain(certs.as_bytes())?;
+
+        let alias_key = fs::read_to_string(&alias).map_err(|error| {
+            IllumosRotMockError::FileRead {
+                path: alias.as_ref().to_path_buf(),
+                error,
+            }
+        })?;
+
+        let alias_key =
+            SigningKey::from_pkcs8_pem(&alias_key).map_err(|error| {
+                IllumosRotMockError::SigningKeyDecode {
+                    path: alias.as_ref().to_path_buf(),
+                    error,
+                }
+            })?;
+
+        Ok(Self { certs, alias_key })
+    }
+}
+
+impl IllumosRot for IllumosRotMock {
+    type Error = IllumosRotMockError;
+
+    fn get_certificates(&self) -> Result<PkiPath, Self::Error> {
+        Ok(self.certs.clone())
+    }
+
+    fn attest(&self, nonce: &Nonce) -> Result<Attestation, Self::Error> {
+        let sig: Signature = self.alias_key.try_sign(nonce.as_ref())?;
+        let sig = P384Signature::from(sig.to_bytes().as_slice().try_into()?);
+        Ok(Attestation::P384(sig))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::*;
+    use std::env;
+
+    #[test]
+    fn bad_path_to_key() {
+        let res = IllumosRotMock::load("root.cert.pem", "foo");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn bad_path_to_certs() {
+        let res = IllumosRotMock::load("foo", "root.key.pem");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn load_success() {
+        let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+        let cert_chain = out.join("root.cert.pem");
+        let key = out.join("root.key.pem");
+
+        let res = IllumosRotMock::load(&cert_chain, &key);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn attest() {
+        let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+        let signing_key = out.join("root.key.pem");
+
+        let mock =
+            IllumosRotMock::load(out.join("root.cert.pem"), &signing_key)
+                .expect("load cert chain & key");
+
+        let nonce = Nonce::from_platform_rng(48).expect("get Nonce from RNG");
+        let attestation = mock.attest(&nonce).expect("attest to nonce");
+        let signing_key = fs::read_to_string(&signing_key)
+            .expect("Read signing key from file to string");
+        let signing_key = SigningKey::from_pkcs8_pem(&signing_key)
+            .expect("signing_key from pkcs8 string");
+
+        use p384::ecdsa::signature::Verifier;
+        let verifying_key = p384::ecdsa::VerifyingKey::from(signing_key);
+        match attestation {
+            Attestation::P384(a) => {
+                let sig = Signature::from_slice(a.as_ref())
+                    .expect("signature from Attestation::P384 bytes");
+                let ret = verifying_key.verify(nonce.as_ref(), &sig);
+                assert!(ret.is_ok());
+            }
+        }
+    }
+}

--- a/helios-rot/test-pki.kdl
+++ b/helios-rot/test-pki.kdl
@@ -1,0 +1,47 @@
+key-pair "root" {
+    p384
+}
+
+entity "root" {
+    country-name "US"
+    state-or-province-name "California"
+    locality-name "Emeryville"
+    organization-name "test"
+    common-name "test ca root"
+}
+
+certificate "root" {
+    // D5B27FE26AEF3BC6949682E19D24B41DA1276B2E
+    serial-number "75B27FE26AEF3BC6949682E19D24B41DA1276B2E"
+    subject-entity "root"
+    subject-key "root"
+    issuer-entity "root"
+    issuer-key "root"
+    digest-algorithm "sha-384"
+    not-before "2022-08-14T10:00:00Z"
+    not-after "9999-12-31T23:59:59Z"
+
+    extensions {
+        basic-constraints critical=true ca=false
+        subject-key-identifier critical=false
+        authority-key-identifier critical=false {
+            key-id
+        }
+        dice-tcb-info-amd critical=true {
+            vendor "FOO"
+            model "Bar"
+            layer 0
+            index 0
+            fwid-list {
+                fwid {
+                    digest-algorithm "sha-384"
+                    digest "ABF643ADBA6635FF09D795E7D9962EE732ED8FE956F7742E28CF38CECC0AFFB5C6D092A91D8E6C45AC5309DBCA1235F6"
+                }
+            }
+            flags {
+                a
+            }
+            type "4F585032" // OXP2
+        }
+    }
+}


### PR DESCRIPTION
Add a new crate to host the interface to & mock of the helios rot. This duplicates some types from `attest-data` as a means to simplify the initial work. Some work remains to determine which types should be shared & which should not.